### PR TITLE
[Feat] 칸반 보드 뷰 생성

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -1,17 +1,89 @@
+import { useState } from 'react';
 import { Button } from '@/components/ui/button.tsx';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from './components/ui/card';
+import {
+	Section,
+	SectionContent,
+	SectionDescription,
+	SectionFooter,
+	SectionHeader,
+	SectionTitle,
+} from './components/ui/section';
+
+const initialColumns = [
+	{
+		id: '0',
+		title: '할 일',
+		tasks: [
+			{ id: '1', title: '프로젝트 계획 수립' },
+			{ id: '2', title: '디자인 초안 작성' },
+			{
+				id: '5',
+				title: `Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publish`,
+			},
+			{ id: '6', title: '디자인 초안 작성' },
+			{ id: '7', title: '디자인 초안 작성' },
+			{ id: '8', title: '디자인 초안 작성' },
+			{ id: '9', title: '디자인 초안 작성' },
+			{ id: '10', title: '디자인 초안 작성' },
+		],
+	},
+	{
+		id: '1',
+		title: '진행 중',
+		tasks: [
+			{ id: '3', title: '프론트엔드 개발' },
+			{ id: '11', title: '프론트엔드 개발' },
+		],
+	},
+	{
+		id: '2',
+		title: '완료',
+		tasks: [{ id: '4', title: '요구사항 분석' }],
+	},
+];
 
 function App() {
+	const [columns, setColumns] = useState(initialColumns); // eslint-disable-line @typescript-eslint/no-unused-vars
+
 	return (
-		<>
-			<h1 className="text-primary p-1 pt-2">Welcome to Harmony!</h1>
-			<p>Harmony 는 일정관리 서비스입니다.</p>
-			<Button>default</Button>
-			<Button variant="destructive">destructive</Button>
-			<Button variant="secondary">secondary</Button>
-			<Button variant="outline">outline</Button>
-			<Button variant="ghost">ghost</Button>
-			<Button variant="link">link</Button>
-		</>
+		<div className="flex h-screen flex-col">
+			<div className="p-4">
+				<h1 className="text-primary pt-2">Welcome to Harmony!</h1>
+				<p>Harmony 는 일정관리 서비스입니다.</p>
+				<Button>default</Button>
+				<Button variant="destructive">destructive</Button>
+				<Button variant="secondary">secondary</Button>
+				<Button variant="outline">outline</Button>
+				<Button variant="ghost">ghost</Button>
+				<Button variant="link">link</Button>
+			</div>
+
+			<div className="flex flex-1 space-x-2 overflow-x-auto p-4">
+				{columns.map((column) => (
+					<Section key={column.id} className="flex w-80 flex-shrink-0 flex-col bg-[#f7f8f9]">
+						<SectionHeader>
+							<SectionTitle>{column.title}</SectionTitle>
+							<SectionDescription>섹션에 대한 추가 설명도 필요할까?</SectionDescription>
+						</SectionHeader>
+						<SectionContent className="flex-1 overflow-y-auto">
+							<div className="space-y-2">
+								{column.tasks.map((task) => (
+									<Card key={task.id} className="bg-[#ffffff]">
+										<CardHeader>
+											<CardTitle>{task.title}</CardTitle>
+										</CardHeader>
+										<CardContent>라벨1 라벨2 라벨3</CardContent>
+										<CardFooter>하위 이슈를 아코디언 형식으로 보여줄 것인가?</CardFooter>
+									</Card>
+								))}
+							</div>
+						</SectionContent>
+						<SectionFooter>+ 이슈 만들기</SectionFooter>
+					</Section>
+				))}
+			</div>
+		</div>
 	);
 }
 

--- a/apps/client/src/components/ui/card.tsx
+++ b/apps/client/src/components/ui/card.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+	({ className, ...props }, ref) => (
+		<div
+			ref={ref}
+			className={cn('bg-card text-card-foreground rounded-xl border shadow', className)}
+			{...props}
+		/>
+	)
+);
+Card.displayName = 'Card';
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+	({ className, ...props }, ref) => (
+		<div ref={ref} className={cn('flex flex-col space-y-1.5 p-4', className)} {...props} />
+	)
+);
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+	({ className, ...props }, ref) => (
+		<div
+			ref={ref}
+			className={cn('text-sm font-medium leading-none tracking-tight', className)}
+			{...props}
+		/>
+	)
+);
+CardTitle.displayName = 'CardTitle';
+
+const CardDescription = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+	({ className, ...props }, ref) => (
+		<div ref={ref} className={cn('text-muted-foreground text-sm', className)} {...props} />
+	)
+);
+CardDescription.displayName = 'CardDescription';
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+	({ className, ...props }, ref) => (
+		<div ref={ref} className={cn('p-4 pt-0 text-sm', className)} {...props} />
+	)
+);
+CardContent.displayName = 'CardContent';
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+	({ className, ...props }, ref) => (
+		<div ref={ref} className={cn('flex items-center p-4 pt-0 text-sm', className)} {...props} />
+	)
+);
+CardFooter.displayName = 'CardFooter';
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/apps/client/src/components/ui/section.tsx
+++ b/apps/client/src/components/ui/section.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Section = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+	({ className, ...props }, ref) => (
+		<div
+			ref={ref}
+			className={cn('bg-card text-card-foreground rounded-xl border shadow', className)}
+			{...props}
+		/>
+	)
+);
+Section.displayName = 'Section';
+
+const SectionHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+	({ className, ...props }, ref) => (
+		<div ref={ref} className={cn('flex flex-col space-y-1.5 p-4', className)} {...props} />
+	)
+);
+SectionHeader.displayName = 'SectionHeader';
+
+const SectionTitle = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+	({ className, ...props }, ref) => (
+		<div
+			ref={ref}
+			className={cn('font-semibold leading-none tracking-tight', className)}
+			{...props}
+		/>
+	)
+);
+SectionTitle.displayName = 'SectionTitle';
+
+const SectionDescription = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+	({ className, ...props }, ref) => (
+		<div ref={ref} className={cn('text-muted-foreground text-sm', className)} {...props} />
+	)
+);
+SectionDescription.displayName = 'SectionDescription';
+
+const SectionContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+	({ className, ...props }, ref) => (
+		<div ref={ref} className={cn('p-2 pt-0', className)} {...props} />
+	)
+);
+SectionContent.displayName = 'SectionContent';
+
+const SectionFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+	({ className, ...props }, ref) => (
+		<div ref={ref} className={cn('flex items-center p-4', className)} {...props} />
+	)
+);
+SectionFooter.displayName = 'SectionFooter';
+
+export { Section, SectionHeader, SectionFooter, SectionTitle, SectionDescription, SectionContent };


### PR DESCRIPTION
## 관련 이슈 번호

#4 

## 작업 내용

- Card 컴포넌트 생성
- Section 컴포넌트 생성
- 두 컴포넌트를 활용하여 칸반 보드 뷰 구현

## 설명

쓰이지 않을 것 같지만 남겨둔 컴포넌트가 몇 개 있는데요.
스크린샷 부분에서 생각을 나열해보겠습니다. ㅎ.ㅎ

### Card 컴포넌트

shadcn의 card 컴포넌트입니다.
padding, font-weight, font-size 등 default 와는 살짝 다른 스타일 사항이 있습니다.

### Section 컴포넌트

Section 컴포넌트를 따로 만들까했지만, shadcn의 card 컴포넌트의 구조가 매력적이었습니다.
그래서 그대로 갖고와 이름만 section 컴포넌트로 바꾸었습니다. 😅
이것 역시 padding 등 default 와는 살짝 다른 스타일 사항이 있습니다.

## 스크린샷

<img width="1025" alt="Screenshot 2024-11-06 at 11 36 53 PM" src="https://github.com/user-attachments/assets/e8a5db02-8b5d-47d8-b1bb-ff7419a4e46d">

깃허브 프로젝트를 좀 따라해봤는데, 어떤가요?

CardDescription도 필요할까요?

CardContent를 활용해서 라벨을 보여주고,
(하위 태스크를 보여줄 것이라면) CardFooter를 활용하면 좋지 않을까? 생각 중입니다.

SectionDescription도 필요할까요?

SectionFooter를 활용하여 새 카드 만들기 버튼을 두면 되겠다! 싶었습니다.

## 논의하면 좋을 사항

### 자료구조

데이터의 형태를 상상해보았습니다.
주엽님이 생각 중이신 형태도 있었을까요?

```js
const initialColumns = [
  {
    id: '0',
    title: '할 일',
    tasks: [
      { id: '1', title: '프로젝트 계획 수립' },
      { id: '2', title: '디자인 초안 작성' },
    ],
  },
  {
    id: '1',
    title: '진행 중',
    tasks: [
      { id: '3', title: '프로젝트 계획 수립' },
    ],
  },
];
```

이것저것 넣어보면 이런 형태가 될 수도 있을 것 같습니다.

```js
{
  id: '0',
  title: '할 일',
  description: '아직 시작되지 않은 일입니다',
  tasks: [
    { id: '1', title: '프로젝트 계획 수립' },
    { id: '2', title: '디자인 초안 작성' },
    {
      id: '6',
      title: '디자인 초안 작성',
      labels: [
        { id: '1', title: 'sprint 1' },
        { id: '4', title: 'story 1' },
      ],
    },
  ],
},
```
