### PR TITLE
[Feat] 단일 태스크 조회 API 구현

### DIFF
--- a/apps/server/src/task/controller/task.controller.ts
+++ b/apps/server/src/task/controller/task.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Param, Patch, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
 import { TaskService } from '../service/task.service';
 import { CreateTaskRequest } from '../dto/create-task-request.dto';
 import { UpdateTaskRequest } from '../dto/update-task-request.dto';
@@ -21,5 +21,10 @@ export class TaskController {
 	@Patch(':id/position')
 	move(@Param('id') id: number, @Body() moveTaskRequest: MoveTaskRequest) {
 		return this.taskService.move(id, moveTaskRequest);
+	}
+
+	@Get(':id')
+	get(@Param('id') id: number) {
+		return this.taskService.get(id);
 	}
 }

--- a/apps/server/src/task/dto/task-response.dto.ts
+++ b/apps/server/src/task/dto/task-response.dto.ts
@@ -1,0 +1,21 @@
+import { Task } from '../domain/task.entity';
+
+export class TaskResponse {
+	constructor(task: Task) {
+		this.id = task.id;
+		this.title = task.title;
+		this.description = task.description;
+		this.sectionName = task.section.name;
+		this.position = task.position;
+	}
+
+	id: number;
+
+	title: string;
+
+	description: string;
+
+	sectionName: string;
+
+	position: string;
+}

--- a/apps/server/src/task/service/task.service.ts
+++ b/apps/server/src/task/service/task.service.ts
@@ -10,7 +10,6 @@ import { UpdateTaskRequest } from '../dto/update-task-request.dto';
 import { UpdateTaskResponse } from '../dto/update-task-response.dto';
 import { MoveTaskRequest } from '../dto/move-task-request.dto';
 import { MoveTaskResponse } from '../dto/move-task-response.dto';
-import { DeleteTaskResponse } from '../dto/delete-task-response.dto';
 import { TaskResponse } from '../dto/task-response.dto';
 
 @Injectable()
@@ -58,6 +57,11 @@ export class TaskService {
 
 		await this.taskRepository.save(task);
 		return new MoveTaskResponse(task);
+	}
+
+	async get(id: number) {
+		const task = await this.findTaskOrThrow(id);
+		return new TaskResponse(task);
 	}
 
 	private async findTaskOrThrow(id: number) {

--- a/apps/server/src/task/service/task.service.ts
+++ b/apps/server/src/task/service/task.service.ts
@@ -51,9 +51,9 @@ export class TaskService {
 		const section = await this.findSectionOrThrow(moveTaskRequest.sectionId);
 		task.section = section;
 
-		const beforePostion = LexoRank.parse(moveTaskRequest.beforePosition);
+		const beforePosition = LexoRank.parse(moveTaskRequest.beforePosition);
 		const afterPosition = LexoRank.parse(moveTaskRequest.afterPosition);
-		task.position = beforePostion.between(afterPosition).toString();
+		task.position = beforePosition.between(afterPosition).toString();
 
 		await this.taskRepository.save(task);
 		return new MoveTaskResponse(task);


### PR DESCRIPTION
## 관련 이슈 번호

close #58 

## 작업 내용

- [x] Task, Section 조회 및 예외처리 코드 함수 분리
- [x] 태스크 조회 API 구현 

## 고민과 학습내용

단일 태스크 조회는 아직 마일스톤에 없어서, 일단 비워두고 올렸습니다.
`Task, Section 조회 및 예외처리 코드 함수 분리` 작업을 먼저 처리해두고 싶어서, 분리하고 바로 사용할 수 있는 단일 조회 API 먼저 구현했습니다 !
`Task, Section 조회 및 예외처리 코드 함수 분리`도 별도 이슈로 분리하는게 나을까요 ?

## 스크린샷

[//]: # (가능한 경우 스크린샷을 첨부해주세요.)