### PR TITLE
[Feat] useForm 훅 및 회원가입 폼 작성

### DIFF
--- a/apps/client/src/components/forms/SignupForm.tsx
+++ b/apps/client/src/components/forms/SignupForm.tsx
@@ -1,0 +1,95 @@
+import { Label } from '@radix-ui/react-label';
+import { useForm } from '@/hooks/useForm.ts';
+import { Input } from '@/components/ui/input.tsx';
+import { Button } from '@/components/ui/button.tsx';
+
+type SignupFormValues = {
+	username: string;
+	password: string;
+	password_confirm: string;
+};
+
+function SignupForm() {
+	const { values, errors, touched, handleChange } = useForm<SignupFormValues>(
+		{
+			username: '',
+			password: '',
+			password_confirm: '',
+		},
+		{
+			username: {
+				required: { value: true, message: '아이디를 입력해주세요.' },
+				minLength: { value: 6, message: '아이디는 6자 이상이어야 합니다.' },
+			},
+			password: {
+				required: { value: true, message: '비밀번호를 입력해주세요.' },
+				minLength: { value: 8, message: '비밀번호는 8자 이상이어야 합니다.' },
+				pattern: {
+					value: /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/,
+					message: '비밀번호는 숫자, 대소문자, 특수문자를 포함해야 합니다.',
+				},
+			},
+			password_confirm: {
+				required: { value: true, message: '비밀번호를 다시 입력해주세요.' },
+				validate: {
+					value: ((value: string) => value === values.password) as (value: string) => boolean,
+					message: '비밀번호가 일치하지 않습니다.',
+				},
+			},
+		}
+	);
+
+	return (
+		<form className="mb-4 bg-white px-8 pb-8 dark:bg-gray-800">
+			<div className="mb-4">
+				{errors.username && touched.username && (
+					<Label htmlFor="username " className="text-destructive pl-2 text-sm">
+						{errors.username}
+					</Label>
+				)}
+				<Input
+					type="text"
+					id="username"
+					value={values.username}
+					onChange={(e) => handleChange('username', e.target.value)}
+					placeholder="아이디"
+					className="h-12 w-full dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+				/>
+			</div>
+			<div className="mb-4">
+				{errors.password && touched.password && (
+					<Label htmlFor="password" className="text-destructive pl-2 text-sm">
+						{errors.password}
+					</Label>
+				)}
+				<Input
+					type="password"
+					id="password"
+					value={values.password}
+					onChange={(e) => handleChange('password', e.target.value)}
+					placeholder="비밀번호"
+					className="h-12 w-full dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+				/>
+			</div>
+			<div className="mb-4">
+				{errors.password_confirm && touched.password_confirm && (
+					<Label htmlFor="password_confirm" className="text-destructive pl-2 text-sm">
+						{errors.password_confirm}
+					</Label>
+				)}
+				<Input
+					type="password"
+					id="password_confirm"
+					value={values.password_confirm}
+					onChange={(e) => handleChange('password_confirm', e.target.value)}
+					placeholder="비밀번호 확인"
+					className="h-12 w-full dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+				/>
+			</div>
+
+			<Button className="text-md h-12 w-full">회원가입하기</Button>
+		</form>
+	);
+}
+
+export default SignupForm;

--- a/apps/client/src/hooks/useForm.ts
+++ b/apps/client/src/hooks/useForm.ts
@@ -1,10 +1,10 @@
 import { useState, useCallback, useEffect } from 'react';
-import type { ValidationRule, FormState } from './useForm.types';
+import type { ValidationRule, FormState, useFormReturnType } from './useForm.types';
 
 export function useForm<T extends { [key: string]: string }>(
 	initialValues: T,
 	validationRules: { [K in keyof T]?: ValidationRule } = {}
-) {
+): useFormReturnType<T> {
 	const [formState, setFormState] = useState<FormState<T>>({
 		values: initialValues,
 		errors: {},

--- a/apps/client/src/hooks/useForm.ts
+++ b/apps/client/src/hooks/useForm.ts
@@ -1,0 +1,120 @@
+import { useState, useCallback, useEffect } from 'react';
+import type { ValidationRule, FormState } from './useForm.types';
+
+export function useForm<T extends { [key: string]: string }>(
+	initialValues: T,
+	validationRules: { [K in keyof T]?: ValidationRule } = {}
+) {
+	const [formState, setFormState] = useState<FormState<T>>({
+		values: initialValues,
+		errors: {},
+		touched: {},
+		isValid: Object.keys(initialValues).reduce((acc, key) => ({ ...acc, [key]: true }), {}),
+		isDirty: {},
+		formIsValid: true,
+		formIsDirty: false,
+	});
+
+	const validateField = useCallback(
+		(name: keyof T, value: string): string => {
+			const rules = validationRules[name];
+			if (!rules) return '';
+
+			const { required, minLength, maxLength, pattern, validate } = rules;
+
+			if (required?.value && !value) {
+				return required.message || '필수 입력 항목입니다';
+			}
+
+			if (minLength && value.length < minLength.value) {
+				return minLength.message || `최소 ${minLength.value}자 이상 입력해주세요`;
+			}
+
+			if (maxLength && value.length > maxLength.value) {
+				return maxLength.message || `최대 ${maxLength.value}자까지 입력 가능합니다`;
+			}
+
+			if (pattern && !pattern.value.test(value)) {
+				return pattern.message || '올바른 형식이 아닙니다';
+			}
+
+			if (validate && !validate.value(value)) {
+				return validate.message || '유효하지 않은 값입니다';
+			}
+
+			return '';
+		},
+		[validationRules]
+	);
+
+	const validateForm = useCallback(() => {
+		let isFormValid = true;
+		const newErrors: { [K in keyof T]?: string } = {};
+
+		Object.keys(formState.values).forEach((key) => {
+			const error = validateField(key as keyof T, formState.values[key as keyof T]);
+			if (error) {
+				newErrors[key as keyof T] = error;
+				isFormValid = false;
+			}
+		});
+
+		setFormState((prev) => ({
+			...prev,
+			errors: newErrors,
+			formIsValid: isFormValid,
+		}));
+	}, [formState.values, validateField]);
+
+	const handleChange = useCallback(
+		(name: keyof T, value: string) => {
+			setFormState((prev) => {
+				const error = validateField(name, value);
+
+				const updatedIsDirty = { ...prev.isDirty, [name]: value !== initialValues[name] };
+				const updatedIsValid = { ...prev.isValid, [name]: !error };
+				const updatedTouched = { ...prev.touched, [name]: true };
+
+				return {
+					...prev,
+					values: { ...prev.values, [name]: value },
+					errors: { ...prev.errors, [name]: error },
+					touched: updatedTouched,
+					isDirty: updatedIsDirty,
+					isValid: updatedIsValid,
+					formIsDirty: Object.values(updatedIsDirty).some(Boolean),
+					formIsValid: Object.values(updatedIsValid).every(Boolean),
+				};
+			});
+		},
+		[initialValues, validateField]
+	);
+
+	const reset = useCallback(() => {
+		setFormState({
+			values: initialValues,
+			errors: {},
+			touched: {},
+			isValid: Object.keys(initialValues).reduce((acc, key) => ({ ...acc, [key]: true }), {}),
+			isDirty: {},
+			formIsValid: true,
+			formIsDirty: false,
+		});
+	}, [initialValues]);
+
+	useEffect(() => {
+		validateForm();
+	}, [validateForm]);
+
+	return {
+		values: formState.values,
+		errors: formState.errors,
+		touched: formState.touched,
+		isValid: formState.isValid,
+		isDirty: formState.isDirty,
+		formIsValid: formState.formIsValid,
+		formIsDirty: formState.formIsDirty,
+		handleChange,
+		reset,
+	};
+}

--- a/apps/client/src/hooks/useForm.ts
+++ b/apps/client/src/hooks/useForm.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback } from 'react';
 import type { ValidationRule, FormState, useFormReturnType } from './useForm.types';
 
 export function useForm<T extends { [key: string]: string }>(
@@ -47,25 +47,6 @@ export function useForm<T extends { [key: string]: string }>(
 		[validationRules]
 	);
 
-	const validateForm = useCallback(() => {
-		let isFormValid = true;
-		const newErrors: { [K in keyof T]?: string } = {};
-
-		Object.keys(formState.values).forEach((key) => {
-			const error = validateField(key as keyof T, formState.values[key as keyof T]);
-			if (error) {
-				newErrors[key as keyof T] = error;
-				isFormValid = false;
-			}
-		});
-
-		setFormState((prev) => ({
-			...prev,
-			errors: newErrors,
-			formIsValid: isFormValid,
-		}));
-	}, [formState.values, validateField]);
-
 	const handleChange = useCallback(
 		(name: keyof T, value: string) => {
 			setFormState((prev) => {
@@ -101,10 +82,6 @@ export function useForm<T extends { [key: string]: string }>(
 			formIsDirty: false,
 		});
 	}, [initialValues]);
-
-	useEffect(() => {
-		validateForm();
-	}, [validateForm]);
 
 	return {
 		values: formState.values,

--- a/apps/client/src/hooks/useForm.types.ts
+++ b/apps/client/src/hooks/useForm.types.ts
@@ -1,0 +1,17 @@
+export type FormState<T> = {
+	values: T;
+	errors: { [K in keyof T]?: string };
+	touched: { [K in keyof T]?: boolean };
+	isValid: { [K in keyof T]?: boolean };
+	isDirty: { [K in keyof T]?: boolean };
+	formIsValid: boolean;
+	formIsDirty: boolean;
+};
+
+export type ValidationRule = {
+	required?: { value: boolean; message?: string };
+	minLength?: { value: number; message?: string };
+	maxLength?: { value: number; message?: string };
+	pattern?: { value: RegExp; message?: string };
+	validate?: { value: (value: string) => boolean; message?: string };
+};

--- a/apps/client/src/hooks/useForm.types.ts
+++ b/apps/client/src/hooks/useForm.types.ts
@@ -15,3 +15,15 @@ export type ValidationRule = {
 	pattern?: { value: RegExp; message?: string };
 	validate?: { value: (value: string) => boolean; message?: string };
 };
+
+export type useFormReturnType<T> = {
+	values: T;
+	errors: { [K in keyof T]?: string };
+	touched: { [K in keyof T]?: boolean };
+	isValid: { [K in keyof T]?: boolean };
+	isDirty: { [K in keyof T]?: boolean };
+	formIsValid: boolean;
+	formIsDirty: boolean;
+	handleChange: (key: keyof T, value: string) => void;
+	reset: () => void;
+};

--- a/apps/client/src/pages/Signup.tsx
+++ b/apps/client/src/pages/Signup.tsx
@@ -1,7 +1,6 @@
 import Header from '@/components/Header.tsx';
-import { Input } from '@/components/ui/input.tsx';
-import { Button } from '@/components/ui/button.tsx';
 import { Github, Harmony } from '@/components/logo';
+import SignupForm from '@/components/forms/SignupForm.tsx';
 
 function Signup() {
 	return (
@@ -14,34 +13,7 @@ function Signup() {
 						<div className="mb-8 pt-12 text-center">
 							<h1 className="text-3xl font-bold">Harmony 시작하기</h1>
 						</div>
-						<form className="mb-4 bg-white px-8 pb-8 dark:bg-gray-800">
-							<div className="mb-4">
-								<Input
-									type="text"
-									id="username"
-									placeholder="아이디"
-									className="h-12 w-full dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-								/>
-							</div>
-							<div className="mb-4">
-								<Input
-									type="password"
-									id="password"
-									placeholder="비밀번호"
-									className="h-12 w-full dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-								/>
-							</div>
-							<div className="mb-4">
-								<Input
-									type="password"
-									id="password_confirm"
-									placeholder="비밀번호 확인"
-									className="h-12 w-full dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-								/>
-							</div>
-
-							<Button className="text-md h-12 w-full">회원가입하기</Button>
-						</form>
+						<SignupForm />
 					</div>
 				</main>
 			</div>


### PR DESCRIPTION

## 관련 이슈 번호

close #22 

## 작업 내용

- useForm 훅 작성
- 회원가입 폼 적용

React Hook Form 과 zod 를 사용하지 않고
모방해서 useForm 이라는 커스텀 훅을 만들었습니다.
`initialValues` 와 `validationRules` 를 넘겨 검증이 가능합니다.

ps.
커스텀 훅으로 만들어봤다는 의미만 있는 것 같아요. 
그냥 React Hook Form 을 사용하는 것이 나을 것 같습니다.

## 스크린샷

https://github.com/user-attachments/assets/08bf9236-40e0-4d62-8389-720a9fe4342e
