### PR TITLE
[Feat] 프로젝트 동적 라우팅 생성

### DIFF
--- a/apps/client/src/routeTree.gen.ts
+++ b/apps/client/src/routeTree.gen.ts
@@ -16,8 +16,12 @@ import { Route as LoginImport } from './routes/login';
 import { Route as AuthImport } from './routes/_auth';
 import { Route as IndexImport } from './routes/index';
 import { Route as AuthAccountImport } from './routes/_auth.account';
+import { Route as AuthProjectImport } from './routes/_auth.$project';
 import { Route as AuthAccountIndexImport } from './routes/_auth.account.index';
+import { Route as AuthProjectIndexImport } from './routes/_auth.$project.index';
 import { Route as AuthAccountSettingsImport } from './routes/_auth.account.settings';
+import { Route as AuthProjectSettingsImport } from './routes/_auth.$project.settings';
+import { Route as AuthProjectBoardImport } from './routes/_auth.$project.board';
 
 // Create/Update Routes
 
@@ -50,16 +54,40 @@ const AuthAccountRoute = AuthAccountImport.update({
 	getParentRoute: () => AuthRoute,
 } as any);
 
+const AuthProjectRoute = AuthProjectImport.update({
+	id: '/$project',
+	path: '/$project',
+	getParentRoute: () => AuthRoute,
+} as any);
+
 const AuthAccountIndexRoute = AuthAccountIndexImport.update({
 	id: '/',
 	path: '/',
 	getParentRoute: () => AuthAccountRoute,
 } as any);
 
+const AuthProjectIndexRoute = AuthProjectIndexImport.update({
+	id: '/',
+	path: '/',
+	getParentRoute: () => AuthProjectRoute,
+} as any);
+
 const AuthAccountSettingsRoute = AuthAccountSettingsImport.update({
 	id: '/settings',
 	path: '/settings',
 	getParentRoute: () => AuthAccountRoute,
+} as any);
+
+const AuthProjectSettingsRoute = AuthProjectSettingsImport.update({
+	id: '/settings',
+	path: '/settings',
+	getParentRoute: () => AuthProjectRoute,
+} as any);
+
+const AuthProjectBoardRoute = AuthProjectBoardImport.update({
+	id: '/board',
+	path: '/board',
+	getParentRoute: () => AuthProjectRoute,
 } as any);
 
 // Populate the FileRoutesByPath interface
@@ -94,6 +122,13 @@ declare module '@tanstack/react-router' {
 			preLoaderRoute: typeof SignupImport;
 			parentRoute: typeof rootRoute;
 		};
+		'/_auth/$project': {
+			id: '/_auth/$project';
+			path: '/$project';
+			fullPath: '/$project';
+			preLoaderRoute: typeof AuthProjectImport;
+			parentRoute: typeof AuthImport;
+		};
 		'/_auth/account': {
 			id: '/_auth/account';
 			path: '/account';
@@ -101,12 +136,33 @@ declare module '@tanstack/react-router' {
 			preLoaderRoute: typeof AuthAccountImport;
 			parentRoute: typeof AuthImport;
 		};
+		'/_auth/$project/board': {
+			id: '/_auth/$project/board';
+			path: '/board';
+			fullPath: '/$project/board';
+			preLoaderRoute: typeof AuthProjectBoardImport;
+			parentRoute: typeof AuthProjectImport;
+		};
+		'/_auth/$project/settings': {
+			id: '/_auth/$project/settings';
+			path: '/settings';
+			fullPath: '/$project/settings';
+			preLoaderRoute: typeof AuthProjectSettingsImport;
+			parentRoute: typeof AuthProjectImport;
+		};
 		'/_auth/account/settings': {
 			id: '/_auth/account/settings';
 			path: '/settings';
 			fullPath: '/account/settings';
 			preLoaderRoute: typeof AuthAccountSettingsImport;
 			parentRoute: typeof AuthAccountImport;
+		};
+		'/_auth/$project/': {
+			id: '/_auth/$project/';
+			path: '/';
+			fullPath: '/$project/';
+			preLoaderRoute: typeof AuthProjectIndexImport;
+			parentRoute: typeof AuthProjectImport;
 		};
 		'/_auth/account/': {
 			id: '/_auth/account/';
@@ -119,6 +175,20 @@ declare module '@tanstack/react-router' {
 }
 
 // Create and export the route tree
+
+interface AuthProjectRouteChildren {
+	AuthProjectBoardRoute: typeof AuthProjectBoardRoute;
+	AuthProjectSettingsRoute: typeof AuthProjectSettingsRoute;
+	AuthProjectIndexRoute: typeof AuthProjectIndexRoute;
+}
+
+const AuthProjectRouteChildren: AuthProjectRouteChildren = {
+	AuthProjectBoardRoute: AuthProjectBoardRoute,
+	AuthProjectSettingsRoute: AuthProjectSettingsRoute,
+	AuthProjectIndexRoute: AuthProjectIndexRoute,
+};
+
+const AuthProjectRouteWithChildren = AuthProjectRoute._addFileChildren(AuthProjectRouteChildren);
 
 interface AuthAccountRouteChildren {
 	AuthAccountSettingsRoute: typeof AuthAccountSettingsRoute;
@@ -133,10 +203,12 @@ const AuthAccountRouteChildren: AuthAccountRouteChildren = {
 const AuthAccountRouteWithChildren = AuthAccountRoute._addFileChildren(AuthAccountRouteChildren);
 
 interface AuthRouteChildren {
+	AuthProjectRoute: typeof AuthProjectRouteWithChildren;
 	AuthAccountRoute: typeof AuthAccountRouteWithChildren;
 }
 
 const AuthRouteChildren: AuthRouteChildren = {
+	AuthProjectRoute: AuthProjectRouteWithChildren,
 	AuthAccountRoute: AuthAccountRouteWithChildren,
 };
 
@@ -147,8 +219,12 @@ export interface FileRoutesByFullPath {
 	'': typeof AuthRouteWithChildren;
 	'/login': typeof LoginRoute;
 	'/signup': typeof SignupRoute;
+	'/$project': typeof AuthProjectRouteWithChildren;
 	'/account': typeof AuthAccountRouteWithChildren;
+	'/$project/board': typeof AuthProjectBoardRoute;
+	'/$project/settings': typeof AuthProjectSettingsRoute;
 	'/account/settings': typeof AuthAccountSettingsRoute;
+	'/$project/': typeof AuthProjectIndexRoute;
 	'/account/': typeof AuthAccountIndexRoute;
 }
 
@@ -157,7 +233,10 @@ export interface FileRoutesByTo {
 	'': typeof AuthRouteWithChildren;
 	'/login': typeof LoginRoute;
 	'/signup': typeof SignupRoute;
+	'/$project/board': typeof AuthProjectBoardRoute;
+	'/$project/settings': typeof AuthProjectSettingsRoute;
 	'/account/settings': typeof AuthAccountSettingsRoute;
+	'/$project': typeof AuthProjectIndexRoute;
 	'/account': typeof AuthAccountIndexRoute;
 }
 
@@ -167,24 +246,52 @@ export interface FileRoutesById {
 	'/_auth': typeof AuthRouteWithChildren;
 	'/login': typeof LoginRoute;
 	'/signup': typeof SignupRoute;
+	'/_auth/$project': typeof AuthProjectRouteWithChildren;
 	'/_auth/account': typeof AuthAccountRouteWithChildren;
+	'/_auth/$project/board': typeof AuthProjectBoardRoute;
+	'/_auth/$project/settings': typeof AuthProjectSettingsRoute;
 	'/_auth/account/settings': typeof AuthAccountSettingsRoute;
+	'/_auth/$project/': typeof AuthProjectIndexRoute;
 	'/_auth/account/': typeof AuthAccountIndexRoute;
 }
 
 export interface FileRouteTypes {
 	fileRoutesByFullPath: FileRoutesByFullPath;
-	fullPaths: '/' | '' | '/login' | '/signup' | '/account' | '/account/settings' | '/account/';
+	fullPaths:
+		| '/'
+		| ''
+		| '/login'
+		| '/signup'
+		| '/$project'
+		| '/account'
+		| '/$project/board'
+		| '/$project/settings'
+		| '/account/settings'
+		| '/$project/'
+		| '/account/';
 	fileRoutesByTo: FileRoutesByTo;
-	to: '/' | '' | '/login' | '/signup' | '/account/settings' | '/account';
+	to:
+		| '/'
+		| ''
+		| '/login'
+		| '/signup'
+		| '/$project/board'
+		| '/$project/settings'
+		| '/account/settings'
+		| '/$project'
+		| '/account';
 	id:
 		| '__root__'
 		| '/'
 		| '/_auth'
 		| '/login'
 		| '/signup'
+		| '/_auth/$project'
 		| '/_auth/account'
+		| '/_auth/$project/board'
+		| '/_auth/$project/settings'
 		| '/_auth/account/settings'
+		| '/_auth/$project/'
 		| '/_auth/account/';
 	fileRoutesById: FileRoutesById;
 }
@@ -225,6 +332,7 @@ export const routeTree = rootRoute
     "/_auth": {
       "filePath": "_auth.tsx",
       "children": [
+        "/_auth/$project",
         "/_auth/account"
       ]
     },
@@ -234,6 +342,15 @@ export const routeTree = rootRoute
     "/signup": {
       "filePath": "signup.tsx"
     },
+    "/_auth/$project": {
+      "filePath": "_auth.$project.tsx",
+      "parent": "/_auth",
+      "children": [
+        "/_auth/$project/board",
+        "/_auth/$project/settings",
+        "/_auth/$project/"
+      ]
+    },
     "/_auth/account": {
       "filePath": "_auth.account.tsx",
       "parent": "/_auth",
@@ -242,9 +359,21 @@ export const routeTree = rootRoute
         "/_auth/account/"
       ]
     },
+    "/_auth/$project/board": {
+      "filePath": "_auth.$project.board.tsx",
+      "parent": "/_auth/$project"
+    },
+    "/_auth/$project/settings": {
+      "filePath": "_auth.$project.settings.tsx",
+      "parent": "/_auth/$project"
+    },
     "/_auth/account/settings": {
       "filePath": "_auth.account.settings.tsx",
       "parent": "/_auth/account"
+    },
+    "/_auth/$project/": {
+      "filePath": "_auth.$project.index.tsx",
+      "parent": "/_auth/$project"
     },
     "/_auth/account/": {
       "filePath": "_auth.account.index.tsx",

--- a/apps/client/src/routes/_auth.$project.board.tsx
+++ b/apps/client/src/routes/_auth.$project.board.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_auth/$project/board')({
+	component: RouteComponent,
+});
+
+function RouteComponent() {
+	const { project } = Route.useParams();
+	return <div>안녕하세요, {project} 칸반 보드 페이지</div>;
+}

--- a/apps/client/src/routes/_auth.$project.index.tsx
+++ b/apps/client/src/routes/_auth.$project.index.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_auth/$project/')({
+	component: RouteComponent,
+});
+
+function RouteComponent() {
+	const { project } = Route.useParams();
+	return <div>안녕하세요, {project} 대시보드 페이지</div>;
+}

--- a/apps/client/src/routes/_auth.$project.settings.tsx
+++ b/apps/client/src/routes/_auth.$project.settings.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_auth/$project/settings')({
+	component: RouteComponent,
+});
+
+function RouteComponent() {
+	const { project } = Route.useParams();
+	return <div>안녕하세요, {project} 설정 페이지</div>;
+}

--- a/apps/client/src/routes/_auth.$project.tsx
+++ b/apps/client/src/routes/_auth.$project.tsx
@@ -1,0 +1,49 @@
+import { createFileRoute, Link, Outlet } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_auth/$project')({
+	component: ProjectLayout,
+});
+
+function ProjectLayout() {
+	const { project } = Route.useParams();
+
+	return (
+		<>
+			<nav className="h-9 border-b px-6">
+				<ul className="flex h-full items-center gap-4 text-sm">
+					<li>
+						<Link
+							to="/$project"
+							params={{ project }}
+							activeOptions={{ exact: true }}
+							className="[&.active]:font-semibold"
+						>
+							Overview
+						</Link>
+					</li>
+					<li>
+						<Link
+							to="/$project/board"
+							params={{ project }}
+							activeOptions={{ exact: true }}
+							className="[&.active]:font-semibold"
+						>
+							Board
+						</Link>
+					</li>
+					<li>
+						<Link
+							to="/$project/settings"
+							params={{ project }}
+							activeOptions={{ exact: true }}
+							className="[&.active]:font-semibold"
+						>
+							Settings
+						</Link>
+					</li>
+				</ul>
+			</nav>
+			<Outlet />
+		</>
+	);
+}

--- a/apps/client/src/routes/_auth.tsx
+++ b/apps/client/src/routes/_auth.tsx
@@ -1,4 +1,11 @@
-import { Link, Outlet, createFileRoute, redirect, useRouter } from '@tanstack/react-router';
+import {
+	Link,
+	Outlet,
+	createFileRoute,
+	redirect,
+	useParams,
+	useRouter,
+} from '@tanstack/react-router';
 import { ChevronsUpDownIcon, LogOut } from 'lucide-react';
 import { Harmony } from '@/components/logo';
 import { Topbar } from '@/components/navigation/topbar';
@@ -22,10 +29,30 @@ export const Route = createFileRoute('/_auth')({
 	component: AuthLayout,
 });
 
+const projectList = [
+	{
+		role: 'ADMIN',
+		project: {
+			id: 1,
+			title: 'project-01',
+			createdAt: '2024-11-12T04:15:54.354Z',
+		},
+	},
+	{
+		role: 'GUEST',
+		project: {
+			id: 2,
+			title: 'project-02',
+			createdAt: '2024-11-12T04:16:01.855Z',
+		},
+	},
+];
+
 function AuthLayout() {
 	const router = useRouter();
 	const navigate = Route.useNavigate();
 	const auth = useAuth();
+	const params = useParams({ strict: false });
 
 	const handleLogout = async () => {
 		try {
@@ -43,19 +70,26 @@ function AuthLayout() {
 			<Topbar
 				leftContent={
 					<>
-						<Link to="/account">
+						<Link to={params.project === undefined ? '/account' : '/$project'}>
 							<Harmony />
 						</Link>
 						<div className="flex items-center gap-2">
-							<div>My Account</div>
+							<h2>{params.project ?? 'My Account'}</h2>
 							<DropdownMenu>
 								<DropdownMenuTrigger className="h-8">
 									<ChevronsUpDownIcon className="h-4 w-4" />
 								</DropdownMenuTrigger>
 								<DropdownMenuContent align="start" className="bg-white">
-									<DropdownMenuItem>My Account</DropdownMenuItem>
-									<DropdownMenuItem>팀 포카드</DropdownMenuItem>
-									<DropdownMenuItem>Web06 project</DropdownMenuItem>
+									<DropdownMenuItem>
+										<Link to="/account">My Account</Link>
+									</DropdownMenuItem>
+									{projectList.map(({ project }) => (
+										<DropdownMenuItem key={project.id}>
+											<Link to="/$project/board" params={{ project: project.title }}>
+												{project.title}
+											</Link>
+										</DropdownMenuItem>
+									))}
 								</DropdownMenuContent>
 							</DropdownMenu>
 						</div>


### PR DESCRIPTION
## 관련 이슈 번호

#38 

## 작업 내용

- 프로젝트에 대한 동적 라우팅 적용

## 스크린샷

https://github.com/user-attachments/assets/623d0468-0569-43ea-9885-677d48d28073

## 함께 논의할 사항

### 프로젝트 이름은 영어로 제한하는 건 어떨까요?

프로젝트명이 uri로 노출되는 것이 좋을것 같다고 느껴서 현재 그렇게 적용된 상태인데요.
tanstack router에서 한글 uri에 대해 새로고침시 active 상태로 인식하지 않는 경우가 있더라고요?!
(이해가 안될것 같아서 영상으로 첨부합니다..)

https://github.com/user-attachments/assets/ee0fa838-657c-4068-8025-3cac3c90742e

그래서 영어로 제한하자고 제안드려봅니다.
~~uri는 영어가 국룰이기도 하니까..~~
~~사실 uri 노출 안 시키면 되는 방법도 있긴 하는데..~~
~~근데 uri 노출시키니까 공백을 "-"로, "-"은 다시 공백으로 바꿔주는 작업이 늘어남~~