### PR TITLE
[Feat] 변경 사항에 대한 병합처리를 위한 queue 기능 구현

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -38,6 +38,7 @@
 		"passport-jwt": "^4.0.1",
 		"reflect-metadata": "^0.2.0",
 		"rxjs": "^7.8.1",
+		"sharedb": "^5.1.1",
 		"typeorm": "^0.3.20"
 	},
 	"devDependencies": {

--- a/apps/server/sharedb.d.ts
+++ b/apps/server/sharedb.d.ts
@@ -1,0 +1,1 @@
+declare module 'sharedb';

--- a/apps/server/src/project/controller/project.controller.ts
+++ b/apps/server/src/project/controller/project.controller.ts
@@ -36,10 +36,6 @@ export class ProjectController {
       await this.projectService.getProject(user.id, projectId)
     );
   }
-  constructor(
-    private projectService: ProjectService,
-    private taskService: TaskService
-  ) {}
 
   @Get(':id/members')
   async getMembers(@AuthUser() user: Account, @Param('id') projectId: number) {
@@ -100,7 +96,7 @@ export class ProjectController {
     @Param('id') projectId: number,
     @Body() taskEvent: TaskEvent
   ) {
-    const event = taskEvent.event;
+    const { event } = taskEvent;
     let response;
     switch (event) {
       case EventType.CREATE_TASK:

--- a/apps/server/src/project/controller/project.controller.ts
+++ b/apps/server/src/project/controller/project.controller.ts
@@ -36,6 +36,10 @@ export class ProjectController {
       await this.projectService.getProject(user.id, projectId)
     );
   }
+  constructor(
+    private projectService: ProjectService,
+    private taskService: TaskService
+  ) {}
 
   @Get(':id/members')
   async getMembers(@AuthUser() user: Account, @Param('id') projectId: number) {
@@ -91,7 +95,11 @@ export class ProjectController {
   }
 
   @Post(':id/update')
-  async handleEvent(@AuthUser() user: Account, @Body() taskEvent: TaskEvent) {
+  async handleEvent(
+    @AuthUser() user: Account,
+    @Param('id') projectId: number,
+    @Body() taskEvent: TaskEvent
+  ) {
     const event = taskEvent.event;
     let response;
     switch (event) {
@@ -106,7 +114,7 @@ export class ProjectController {
         break;
       case EventType.INSERT_TITLE:
       case EventType.DELETE_TITLE:
-        // response = await this.taskService.update(user.id, taskEvent);
+        response = await this.taskService.enqueue(user.id, projectId, taskEvent);
         break;
       default:
         throw new BadRequestException('올바르지 않은 이벤트 타입입니다.');

--- a/apps/server/src/task/controller/task.controller.ts
+++ b/apps/server/src/task/controller/task.controller.ts
@@ -41,19 +41,6 @@ export class TaskController {
     );
   }
 
-  @Patch(':id/status')
-  async update(
-    @AuthUser() user: Account,
-    @Param('id') id: number,
-    @Body() updateTaskRequest: UpdateTaskRequest
-  ) {
-    return new BaseResponse(
-      200,
-      '태스크가 정상적으로 수정되었습니다.',
-      await this.taskService.update(id, user.id, updateTaskRequest)
-    );
-  }
-
   @Patch(':id/position')
   async move(@Param('id') id: number, @Body() moveTaskRequest: MoveTaskRequest) {
     return new BaseResponse(

--- a/apps/server/src/task/service/task.service.ts
+++ b/apps/server/src/task/service/task.service.ts
@@ -113,7 +113,7 @@ export class TaskService {
         return [
           {
             p: [position],
-            sd: existingTitle.slice(position, position + length),
+            sd: content,
           },
         ];
       default:

--- a/apps/server/src/task/service/task.service.ts
+++ b/apps/server/src/task/service/task.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { LexoRank } from 'lexorank';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import ShareDB from 'sharedb';
+import * as ShareDB from 'sharedb';
 import { Task } from '@/task/domain/task.entity';
 import { Section } from '@/task/domain/section.entity';
 import { MoveTaskRequest } from '@/task/dto/move-task-request.dto';


### PR DESCRIPTION
## 관련 이슈 번호

close #89 

## 작업 내용

- [x] 변경 사항 TaskEvent 형태로 Queue에 enqueue
- [x] EventEmitter를 통해, enqueue 시 이벤트 발생
- [x] 이벤트 수신하여 dequeue
- [x] shareDB의 json0을 활용한 텍스트 병합  