### PR TITLE
[Feat] 초대받은 프로젝트 목록 조회, 승인/거절 기능 구현

### DIFF
--- a/apps/client/src/pages/AccountSettings.tsx
+++ b/apps/client/src/pages/AccountSettings.tsx
@@ -1,0 +1,132 @@
+import axios from 'axios';
+import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { Check, Inbox, X } from 'lucide-react';
+import TabView from '@/components/TabView';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useAuth } from '@/contexts/authContext';
+import { Button } from '@/components/ui/button';
+import {
+  GetProjectInvitationsResponseDTO,
+  HandleProjectInvitationRequestDTO,
+} from '@/types/project';
+
+function AccountSettings() {
+  const auth = useAuth();
+  const queryClient = useQueryClient();
+  const { data: invitations } = useSuspenseQuery({
+    queryKey: ['project', 'invitations'],
+    queryFn: async () => {
+      try {
+        const invitations = await axios.get<GetProjectInvitationsResponseDTO>(
+          '/api/project/invitations',
+          {
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${auth.accessToken}`,
+            },
+          }
+        );
+        return invitations.data.result;
+      } catch {
+        throw new Error('Failed to fetch invitations');
+      }
+    },
+  });
+  const { mutate } = useMutation({
+    mutationFn: async ({
+      projectId,
+      payload,
+    }: {
+      projectId: number;
+      payload: HandleProjectInvitationRequestDTO;
+    }) => {
+      await axios.patch(`/api/project/${projectId}/invite`, payload, {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${auth.accessToken}`,
+        },
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['project', 'invitations'] });
+    },
+    onError: (error) => {
+      alert('Failed to respond to invitation');
+      console.log('Failed to respond to invitation', error);
+    },
+  });
+
+  const handleAcceptButtonClick = (contributorId: number, projectId: number) => {
+    mutate({ projectId, payload: { contributorId, status: 'ACCEPTED' } });
+  };
+
+  const handleDeclineButtonClick = (contributorId: number, projectId: number) => {
+    mutate({ projectId, payload: { contributorId, status: 'REJECTED' } });
+  };
+
+  return (
+    <TabView>
+      <TabView.Title>Account Settings</TabView.Title>
+      <TabView.Content>
+        <Card className="bg-white">
+          <CardHeader>
+            <CardTitle className="text-xl">Pending Invitations</CardTitle>
+            <CardDescription className="text-gray-500">
+              Manage your pending team invitations.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {invitations.length > 0 ? (
+                invitations.map((invitation) => (
+                  <div
+                    key={invitation.contributorId}
+                    className="flex items-center justify-between rounded-lg border bg-[#fafafa] p-4"
+                  >
+                    <div className="flex items-center space-x-4">
+                      <div className="h-8 w-8 rounded-full bg-[#2ecc71]" />
+                      <div>
+                        <p className="text-lg font-medium">{invitation.projectTitle}</p>
+                        <p className="text-sm text-gray-500">Invited by {invitation.inviter}</p>
+                      </div>
+                    </div>
+                    <div className="flex space-x-2">
+                      <Button
+                        className="bg-black hover:bg-black/80"
+                        onClick={() =>
+                          handleAcceptButtonClick(invitation.contributorId, invitation.projectId)
+                        }
+                      >
+                        <Check className="h-4 w-4" />
+                        Accept
+                      </Button>
+                      <Button
+                        className="bg-white text-black hover:bg-white/80"
+                        onClick={() =>
+                          handleDeclineButtonClick(invitation.contributorId, invitation.projectId)
+                        }
+                      >
+                        <X className="h-4 w-4" />
+                        Decline
+                      </Button>
+                    </div>
+                  </div>
+                ))
+              ) : (
+                <div className="py-12 text-center">
+                  <Inbox className="mx-auto h-12 w-12" />
+                  <h3 className="mt-2 text-lg font-medium">No invitations</h3>
+                  <p className="mt-1 text-gray-500">
+                    You don&apos;t have any pending project invitations.
+                  </p>
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </TabView.Content>
+    </TabView>
+  );
+}
+
+export default AccountSettings;

--- a/apps/client/src/routes/_auth.account.settings.tsx
+++ b/apps/client/src/routes/_auth.account.settings.tsx
@@ -1,13 +1,30 @@
+import axios from 'axios';
 import { createFileRoute } from '@tanstack/react-router';
+import AccountSettings from '@/pages/AccountSettings';
+import { GetProjectInvitationsResponseDTO } from '@/types/project';
 
 export const Route = createFileRoute('/_auth/account/settings')({
-  component: RouteComponent,
+  loader: ({ context: { auth, queryClient } }) => {
+    queryClient.ensureQueryData({
+      queryKey: ['project', 'invitations'],
+      queryFn: async () => {
+        try {
+          const invitations = await axios.get<GetProjectInvitationsResponseDTO>(
+            '/api/project/invitations',
+            {
+              headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${auth.accessToken}`,
+              },
+            }
+          );
+          return invitations.data.result;
+        } catch {
+          throw new Error('Failed to fetch invitations');
+        }
+      },
+    });
+  },
+  errorComponent: () => <div>Failed to load invitations</div>,
+  component: AccountSettings,
 });
-
-function RouteComponent() {
-  return (
-    <div>
-      <h2>계정 설정 페이지</h2>
-    </div>
-  );
-}

--- a/apps/client/src/types/project.ts
+++ b/apps/client/src/types/project.ts
@@ -31,3 +31,21 @@ export interface InviteProjectMemberRequestDTO {
   username: string;
   projectId: number;
 }
+
+export interface ProjectInvitation {
+  contributorId: number;
+  projectId: number;
+  projectTitle: string;
+  inviter: string;
+}
+
+export interface GetProjectInvitationsResponseDTO {
+  status: number;
+  message: string;
+  result: ProjectInvitation[];
+}
+
+export interface HandleProjectInvitationRequestDTO {
+  contributorId: number;
+  status: 'ACCEPTED' | 'REJECTED';
+}


### PR DESCRIPTION
> [!Warning]
> 이번에도 한 파일에 몰아넣었습니다. 데모 때 보여주려면 있어야 할 기능 같아서 급하게 만듭니다.

## 관련 이슈 번호

#87 

## 작업 내용

- 프로젝트 초대 받은 목록 뷰
- 프로젝트 초대 받은 목록 조회 API 연동
- 프로젝트 멤버 초대 승인/거절 API 연동

## 스크린샷


https://github.com/user-attachments/assets/faa8a728-d6dc-45cd-b4cd-005782ac26f1
