### PR TITLE
[Feat] 변경된 필드별로 이벤트 나눠서 적용하기

### DIFF
--- a/apps/client/src/components/KanbanBoard.tsx
+++ b/apps/client/src/components/KanbanBoard.tsx
@@ -34,7 +34,7 @@ import TaskTextArea from '@/components/TaskTextArea.tsx';
 
 export interface Event {
   taskId: number;
-  event: string;
+  taskEvent: string;
 }
 
 export type Task = {
@@ -89,7 +89,19 @@ export default function KanbanBoard() {
           signal: ac.signal,
         });
 
-        if (response.data.result?.taskId) {
+        const { taskId, taskEvent } = response.data.result;
+
+        if (!taskId) {
+          return;
+        }
+
+        if (taskEvent === 'TITLE') {
+          queryClient.invalidateQueries({
+            queryKey: ['task-detail', taskId],
+          });
+        }
+
+        if (taskEvent === 'CARD') {
           queryClient.invalidateQueries({
             queryKey: ['tasks', projectId],
           });
@@ -279,8 +291,6 @@ export default function KanbanBoard() {
     });
   };
 
-  // update task title
-
   // render
   const sortedSections = sections.map((section) => {
     section.tasks.sort((a, b) => a.position.localeCompare(b.position));
@@ -337,7 +347,7 @@ export default function KanbanBoard() {
           >
             {section.tasks.map((task) => (
               <motion.div
-                key={`${task.id}-${task.title}`}
+                key={task.id}
                 layout
                 layoutId={task.id.toString()}
                 draggable

--- a/apps/client/src/components/TaskTextArea.tsx
+++ b/apps/client/src/components/TaskTextArea.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent, CompositionEvent, useEffect, useRef, useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { useParams } from '@tanstack/react-router';
 import { useAuth } from '@/contexts/authContext.tsx';
@@ -29,6 +29,32 @@ export default function TaskTextArea({
       prevTitleRef.current = initialTitle;
     }
   }, [initialTitle]);
+
+  const { data: updatedTitle } = useQuery({
+    queryKey: ['task-detail', taskId],
+    queryFn: async () => {
+      const response = await axios.get<{
+        status: number;
+        message: string;
+        result: {
+          id: number;
+          title: string;
+        };
+      }>(`/api/task/${taskId}`, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      return response.data.result.title;
+    },
+    initialData: initialTitle,
+  });
+
+  useEffect(() => {
+    if (updatedTitle !== prevTitleRef.current) {
+      setLocalTitle(updatedTitle);
+      prevTitleRef.current = updatedTitle;
+    }
+  }, [updatedTitle]);
 
   const { mutate: updateTitle } = useMutation({
     mutationFn: async ({ position, content, event }: TextDiff) => {

--- a/apps/server/src/task/dto/task-event-response.dto.ts
+++ b/apps/server/src/task/dto/task-event-response.dto.ts
@@ -1,9 +1,18 @@
 export class TaskEventResponse {
   taskId: number;
 
+  taskEvent: string;
+
   static from(taskId: number) {
     const response = new TaskEventResponse();
     response.taskId = taskId;
+    return response;
+  }
+
+  static of(taskId: number, taskEvent: string) {
+    const response = new TaskEventResponse();
+    response.taskId = taskId;
+    response.taskEvent = taskEvent;
     return response;
   }
 }

--- a/apps/server/src/task/service/task.service.ts
+++ b/apps/server/src/task/service/task.service.ts
@@ -86,7 +86,12 @@ export class TaskService {
     const result = { ...initialTask, title: newText };
     await this.taskRepository.save(result);
     const eventPublisher = accumulateOperations.length <= 1 ? userId : null;
-    this.eventEmitter.emit('broadcast', eventPublisher, projectId, TaskEventResponse.from(taskId));
+    this.eventEmitter.emit(
+      'broadcast',
+      eventPublisher,
+      projectId,
+      TaskEventResponse.of(taskId, 'TITLE')
+    );
   }
 
   private convertToOperation(taskEvent: TaskEvent) {
@@ -120,7 +125,7 @@ export class TaskService {
       section,
     });
 
-    this.eventEmitter.emit('broadcast', userId, projectId, TaskEventResponse.from(task.id));
+    this.eventEmitter.emit('broadcast', userId, projectId, TaskEventResponse.of(task.id, 'CARD'));
     return new CreateTaskResponse(task);
   }
 
@@ -175,7 +180,7 @@ export class TaskService {
       'broadcast',
       userId,
       projectId,
-      TaskEventResponse.from(taskEvent.taskId)
+      TaskEventResponse.of(taskEvent.taskId, 'CARD')
     );
     return new MoveTaskResponse(task);
   }
@@ -210,7 +215,7 @@ export class TaskService {
       'broadcast',
       userId,
       projectId,
-      TaskEventResponse.from(taskEvent.taskId)
+      TaskEventResponse.of(taskEvent.taskId, 'CARD')
     );
     return new DeleteTaskResponse(taskEvent.taskId);
   }


### PR DESCRIPTION
## 관련 이슈 번호

close #115 

## 작업 내용

- 서버 측에서 수신한 이벤트별로 `taskEvent` 값 설정하기
- 클라이언트 측에서 수신한 `taskEvent` 로 화면 업데이트 로직 나누기