### PR TITLE
[BugFix] 플래닝 포커 Socket API 연동 문제 해결

### DIFF
--- a/apps/server/src/planning-poker/gateway/planning-poker.gateway.ts
+++ b/apps/server/src/planning-poker/gateway/planning-poker.gateway.ts
@@ -76,18 +76,17 @@ export class PlanningPokerGateway implements OnGatewayConnection, OnGatewayDisco
     const { projectId } = payload;
     const projectCards = this.getProjectCardsOrThrow(projectId);
 
-    const cardDetails = Array.from(projectCards.entries())
-      .filter(([userId, data]) => {
-        return data.card !== '';
-      })
-      .map(([userId, data]) => ({
-        userId,
-        card: data.card,
-      }));
-
-    if (cardDetails.length <= 0) {
+    const hasNonEmptyCards = Array.from(projectCards.entries()).some(
+      ([userId, data]) => data.card !== ''
+    );
+    if (!hasNonEmptyCards) {
       return;
     }
+
+    const cardDetails = Array.from(projectCards.entries()).map(([userId, data]) => ({
+      userId,
+      card: data.card,
+    }));
 
     this.server.to(projectId).emit('card_revealed', cardDetails);
   }

--- a/apps/server/src/planning-poker/gateway/planning-poker.gateway.ts
+++ b/apps/server/src/planning-poker/gateway/planning-poker.gateway.ts
@@ -32,8 +32,8 @@ export class PlanningPokerGateway implements OnGatewayConnection, OnGatewayDisco
       username: data.username,
     }));
 
-    client.emit('user_updated', userDetails);
-    this.server.to(projectId).emit('user_joined', { userId: id, username });
+    client.emit('users_fetched', userDetails);
+    this.broadcastToOthers(client, 'user_joined', { userId: id, username });
   }
 
   handleDisconnect(client: Socket) {
@@ -71,6 +71,7 @@ export class PlanningPokerGateway implements OnGatewayConnection, OnGatewayDisco
     this.broadcastToOthers(client, 'card_selected', { userId });
   }
 
+  // TO DO: 1명이라도 선택한 카드가 있을 때만 리벨 카드 가능하도록 수정
   @SubscribeMessage('reveal_card')
   handleRevealCard(client: Socket, payload: { projectId: string }) {
     const { projectId } = payload;

--- a/apps/server/src/planning-poker/gateway/planning-poker.gateway.ts
+++ b/apps/server/src/planning-poker/gateway/planning-poker.gateway.ts
@@ -71,16 +71,23 @@ export class PlanningPokerGateway implements OnGatewayConnection, OnGatewayDisco
     this.broadcastToOthers(client, 'card_selected', { userId });
   }
 
-  // TO DO: 1명이라도 선택한 카드가 있을 때만 리벨 카드 가능하도록 수정
   @SubscribeMessage('reveal_card')
   handleRevealCard(client: Socket, payload: { projectId: string }) {
     const { projectId } = payload;
     const projectCards = this.getProjectCardsOrThrow(projectId);
 
-    const cardDetails = Array.from(projectCards.entries()).map(([userId, card]) => ({
-      userId,
-      card,
-    }));
+    const cardDetails = Array.from(projectCards.entries())
+      .filter(([userId, data]) => {
+        return data.card !== '';
+      })
+      .map(([userId, data]) => ({
+        userId,
+        card: data.card,
+      }));
+
+    if (cardDetails.length <= 0) {
+      return;
+    }
 
     this.server.to(projectId).emit('card_revealed', cardDetails);
   }


### PR DESCRIPTION
## 관련 이슈 번호

close #128 

## 작업 내용

- [x] user_joined 이벤트가 poroject 내, 모든 클라이언트에게 브로드캐스트 되는 문제 해결
- [x] 카드를 선택한 사람이 아무도 없을 경우, `card_revealed` 이벤트를 emit하지 않는 기능 추가