### PR TITLE
[BugFix] Socket.IO 에서 disconnect 시, rooms에서 자동 삭제되는 이슈 해결

### DIFF
--- a/apps/server/src/planning-poker/gateway/planning-poker.gateway.ts
+++ b/apps/server/src/planning-poker/gateway/planning-poker.gateway.ts
@@ -38,16 +38,19 @@ export class PlanningPokerGateway implements OnGatewayConnection, OnGatewayDisco
 
   handleDisconnect(client: Socket) {
     const userId = client.data.user.id;
+    const projectId = Array.from(this.selectedCards.entries()).find(([_, projectCards]) =>
+      projectCards.has(userId)
+    )?.[0];
 
-    client.rooms.forEach((projectId) => {
-      client.leave(projectId);
-    });
+    if (!projectId) {
+      return;
+    }
+
+    this.server.to(projectId).emit('user_left', { userId });
 
     this.selectedCards.forEach((projectCards) => {
       projectCards.delete(userId);
     });
-
-    this.broadcastToOthers(client, 'user_left', { userId });
   }
 
   @SubscribeMessage('select_card')


### PR DESCRIPTION
## 관련 이슈 번호

close #132 

## 작업 내용

- [x] Socket.IO 에서 disconnect 시, rooms에서 자동 삭제되는 이슈 해결

## 고민과 학습내용

Socket.IO 에서 disconnect 시, rooms에서 자동 삭제되는 이슈가 있었습니다.
따라서, 기존에 인메모리에서 관리하던 Map에서 userId를 통해 projectId를 추출하여 `user_left`를 브로드캐스팅하도록 변경했습니다.
