### PR TITLE
[Feat] 프로필 관련 기능 구현

### DIFF
--- a/apps/client/src/components/PlanningPokerFloatingButton.tsx
+++ b/apps/client/src/components/PlanningPokerFloatingButton.tsx
@@ -5,6 +5,7 @@ import { io, Socket } from 'socket.io-client';
 import { Harmony } from './logo';
 import { Button } from './ui/button';
 import { useAuth } from '@/features/auth/useAuth.ts';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 
 const CARDS = ['☕️', '8', '4', '2', '1'];
 
@@ -64,6 +65,7 @@ interface User {
   userId: number;
   name: string;
   selectedCard: string;
+  profileImage: string;
 }
 
 function PlanningPokerFloatingButton() {
@@ -113,16 +115,20 @@ function PlanningPokerFloatingButton() {
         withCredentials: true,
       });
 
-      socketRef.current.on('user_joined', (data: { userId: number; username: string }) => {
-        setUsers((prevUsers) => [
-          {
-            userId: data.userId,
-            name: data.username,
-            selectedCard: '',
-          },
-          ...prevUsers,
-        ]);
-      });
+      socketRef.current.on(
+        'user_joined',
+        (data: { userId: number; username: string; profileImage: string }) => {
+          setUsers((prevUsers) => [
+            {
+              userId: data.userId,
+              name: data.username,
+              selectedCard: '',
+              profileImage: data.profileImage,
+            },
+            ...prevUsers,
+          ]);
+        }
+      );
 
       socketRef.current.on('user_left', (data: { userId: number }) => {
         setUsers((prevUsers) => prevUsers.filter((user) => user.userId !== data.userId));
@@ -136,6 +142,7 @@ function PlanningPokerFloatingButton() {
             userId: number;
             username: string;
             card: string;
+            profileImage: string;
           }[];
         }) => {
           setUsers(
@@ -143,6 +150,7 @@ function PlanningPokerFloatingButton() {
               userId: user.userId,
               name: user.username,
               selectedCard: user.card,
+              profileImage: user.profileImage,
             }))
           );
           setIsRevealed(data.isRevealed);
@@ -252,7 +260,12 @@ function PlanningPokerFloatingButton() {
                   className="flex flex-row-reverse gap-2"
                 >
                   <div className="flex w-9 flex-col items-center gap-1">
-                    <div className="h-7 w-7 rounded-full bg-[#333333]" /> {/* 프로필 이미지 */}
+                    <Avatar className="h-8 w-8 rounded-full shadow">
+                      <AvatarImage src={user.profileImage} className="object-cover" alt="Avatar" />
+                      <AvatarFallback>
+                        <div className="h-full w-full bg-gradient-to-br from-purple-600 via-fuchsia-500 to-pink-500" />
+                      </AvatarFallback>
+                    </Avatar>
                     <span className="text-xs text-gray-600">
                       {index === users.length - 1 ? 'Me' : truncateName(user.name, 4)}
                     </span>

--- a/apps/client/src/features/auth/AuthProvider.tsx
+++ b/apps/client/src/features/auth/AuthProvider.tsx
@@ -18,6 +18,7 @@ export interface AuthContextValue extends AuthState {
     typeof useMutation<BaseResponse<RegisterResult>, Error, RegisterRequestDto>
   >;
   logoutMutation: ReturnType<typeof useMutation<BaseResponse, Error, void>>;
+  updateProfileImage: (newProfileImage: string) => void;
 }
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
@@ -26,6 +27,7 @@ const INITIAL_STATE: AuthState = {
   isAuthenticated: false,
   username: '',
   accessToken: '',
+  profileImage: '',
 };
 
 const getStoredState = () => {
@@ -67,6 +69,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         isAuthenticated: true,
         username: data.result.username,
         accessToken: data.result.accessToken,
+        profileImage: data.result.profileImage,
       });
       queryClient.clear();
     },
@@ -82,12 +85,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     },
   });
 
+  const updateProfileImage = (newProfileImage: string) => {
+    setAuthState((prevState) => ({
+      ...prevState,
+      profileImage: newProfileImage,
+    }));
+  };
+
   const value = useMemo(
     () => ({
       ...authState,
       loginMutation,
       registerMutation,
       logoutMutation,
+      updateProfileImage,
     }),
     [authState, loginMutation, registerMutation, logoutMutation]
   );

--- a/apps/client/src/features/auth/api.ts
+++ b/apps/client/src/features/auth/api.ts
@@ -1,4 +1,5 @@
-import { axiosInstance } from '@/lib/axios.ts';
+import axios from 'axios';
+import { axiosInstance } from '@/lib/axios';
 import { BaseResponse } from '@/features/types.ts';
 import {
   LoginRequestDto,
@@ -9,10 +10,7 @@ import {
 
 export const authAPI = {
   login: async (loginRequestDto: LoginRequestDto) => {
-    const { data } = await axiosInstance.post<BaseResponse<LoginResult>>(
-      '/auth/signin',
-      loginRequestDto
-    );
+    const { data } = await axios.post<BaseResponse<LoginResult>>('/auth/signin', loginRequestDto);
 
     return data;
   },
@@ -24,7 +22,7 @@ export const authAPI = {
   },
 
   register: async (registerRequestDto: RegisterRequestDto) => {
-    const { data } = await axiosInstance.post<BaseResponse<RegisterResult>>(
+    const { data } = await axios.post<BaseResponse<RegisterResult>>(
       '/auth/signup',
       registerRequestDto
     );

--- a/apps/client/src/features/auth/types.ts
+++ b/apps/client/src/features/auth/types.ts
@@ -2,6 +2,7 @@ export interface AuthState {
   isAuthenticated: boolean;
   username: string;
   accessToken: string;
+  profileImage: string;
 }
 
 export interface LoginRequestDto {
@@ -13,6 +14,7 @@ export interface LoginResult {
   id: number;
   username: string;
   accessToken: string;
+  profileImage: string;
 }
 
 export interface RegisterRequestDto {

--- a/apps/client/src/lib/axios.ts
+++ b/apps/client/src/lib/axios.ts
@@ -47,8 +47,8 @@ axiosInstance.interceptors.response.use(
         throw new Error('Refresh token failed');
       }
 
-      const { username, accessToken } = response.data.result;
-      const authStorage: AuthState = { accessToken, isAuthenticated: true, username };
+      const { username, accessToken, profileImage } = response.data.result;
+      const authStorage: AuthState = { accessToken, isAuthenticated: true, username, profileImage };
 
       localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(authStorage));
 

--- a/apps/client/src/routes/_auth.tsx
+++ b/apps/client/src/routes/_auth.tsx
@@ -143,6 +143,7 @@ function AuthLayout() {
       setPreviewUrl(undefined);
       setSelectedFile(undefined);
       setIsProfileOpen(false);
+      toast.success('Image uploaded successfully.');
     },
     onError: () => {
       toast.error('Failed to upload image.');


### PR DESCRIPTION
## 관련 이슈 번호

#148 

## 작업 내용

- 이제 로그인시 localStorage에 이미지 url을 포함합니다.(profileImage)
- authProvider에 프로필이미지(profileImage)와 세터함수(upadteProfileImage)를 제공합니다.
- 플래닝 포커에도 프로필 이미지를 갖고 오도록 수정했습니다.
- 프로필 이미지 수정 기능이 추가되었습니다.

## 고민과 학습내용

ncp CORS 설정은 코드레벨에서
https://guide.ncloud-docs.com/docs/storage-storage-8-4

## 스크린샷

https://github.com/user-attachments/assets/d635cc40-fc34-4553-9e1f-bf7e4132faff
