### PR TITLE
[Feat] 대시보드 워크로드 뷰, 기능 구현

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-icons": "^1.3.1",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-popover": "^1.1.2",
+    "@radix-ui/react-progress": "^1.1.0",
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@tanstack/react-query": "^5.59.20",

--- a/apps/client/src/components/ProjectCard.tsx
+++ b/apps/client/src/components/ProjectCard.tsx
@@ -1,6 +1,3 @@
-import { MoreVertical } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-
 type Project = {
   id: number;
   title: string;
@@ -10,7 +7,7 @@ type Project = {
 
 function ProjectCard({ project }: { project: Project }) {
   return (
-    <div className="rounded-lg border-b bg-white">
+    <div className="rounded-lg border bg-white hover:border-green-400">
       <div className="flex items-center justify-between p-4">
         <div className="flex items-center gap-3">
           <div className="h-8 w-8 rounded-full bg-[#2ecc71]" />
@@ -23,9 +20,6 @@ function ProjectCard({ project }: { project: Project }) {
             </p>
           </div>
         </div>
-        <Button variant="ghost" size="icon">
-          <MoreVertical />
-        </Button>
       </div>
     </div>
   );

--- a/apps/client/src/components/ui/progress.tsx
+++ b/apps/client/src/components/ui/progress.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import * as ProgressPrimitive from '@radix-ui/react-progress';
+
+import { cn } from '@/lib/utils';
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn('bg-primary/20 relative h-2 w-full overflow-hidden rounded-full', className)}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="bg-primary h-full w-full flex-1 transition-all"
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+));
+Progress.displayName = ProgressPrimitive.Root.displayName;
+
+export { Progress };

--- a/apps/client/src/components/ui/table.tsx
+++ b/apps/client/src/components/ui/table.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <div className="relative w-full overflow-auto">
+      <table ref={ref} className={cn('w-full caption-bottom text-sm', className)} {...props} />
+    </div>
+  )
+);
+Table.displayName = 'Table';
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+));
+TableHeader.displayName = 'TableHeader';
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody ref={ref} className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+));
+TableBody.displayName = 'TableBody';
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn('bg-muted/50 border-t font-medium [&>tr]:last:border-b-0', className)}
+    {...props}
+  />
+));
+TableFooter.displayName = 'TableFooter';
+
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr
+      ref={ref}
+      className={cn(
+        'hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+TableRow.displayName = 'TableRow';
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      'text-muted-foreground h-10 px-2 text-left align-middle font-medium [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+      className
+    )}
+    {...props}
+  />
+));
+TableHead.displayName = 'TableHead';
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn(
+      'p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+      className
+    )}
+    {...props}
+  />
+));
+TableCell.displayName = 'TableCell';
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption ref={ref} className={cn('text-muted-foreground mt-4 text-sm', className)} {...props} />
+));
+TableCaption.displayName = 'TableCaption';
+
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/apps/client/src/features/auth/AuthProvider.tsx
+++ b/apps/client/src/features/auth/AuthProvider.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/features/auth/types.ts';
 import { authAPI } from '@/features/auth/api.ts';
 import { BaseResponse } from '@/features/types.ts';
+import { useToast } from '@/lib/useToast';
 
 export interface AuthContextValue extends AuthState {
   loginMutation: ReturnType<typeof useMutation<BaseResponse<LoginResult>, Error, LoginRequestDto>>;
@@ -46,6 +47,7 @@ const getStoredState = () => {
 export function AuthProvider({ children }: { children: ReactNode }) {
   const queryClient = useQueryClient();
   const [authState, setAuthState] = useState<AuthState>(getStoredState());
+  const toast = useToast();
 
   useEffect(() => {
     localStorage.setItem(ENV.AUTH_STORAGE_KEY, JSON.stringify(authState));
@@ -57,6 +59,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     },
     onSuccess: () => {
       window.location.href = '/login';
+    },
+    onError: () => {
+      toast.error('Failed to register. Please try again.');
     },
   });
 

--- a/apps/client/src/pages/AccountOverview.tsx
+++ b/apps/client/src/pages/AccountOverview.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
 import { Button } from '@/components/ui/button';
 import TabView from '@/components/TabView';
 import ProjectCard from '@/components/ProjectCard';
@@ -64,7 +65,9 @@ function AccountOverview() {
         </div>
         <div className="flex flex-col gap-2">
           {projects.map((project) => (
-            <ProjectCard key={project.id} project={project} />
+            <Link to="/$project/board" params={{ project: String(project.id) }} key={project.id}>
+              <ProjectCard project={project} />
+            </Link>
           ))}
         </div>
       </TabView.Content>

--- a/apps/client/src/pages/AccountOverview.tsx
+++ b/apps/client/src/pages/AccountOverview.tsx
@@ -6,10 +6,13 @@ import ProjectCard from '@/components/ProjectCard';
 import CreateProjectDialog from '@/components/dialog/CreateProjectDialog';
 import { CreateProjectRequestDTO, GetProjectsResponseDTO } from '@/types/project';
 import { axiosInstance } from '@/lib/axios.ts';
+import { useToast } from '@/lib/useToast';
 
 function AccountOverview() {
   const queryClient = useQueryClient();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const toast = useToast();
+
   const { data: projects } = useSuspenseQuery({
     queryKey: ['projects'],
     queryFn: async () => {
@@ -28,9 +31,10 @@ function AccountOverview() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['projects'] });
       setIsDialogOpen(false);
+      toast.success('Project created successfully.');
     },
-    onError: (error) => {
-      console.log('Failed to create project', error);
+    onError: () => {
+      toast.error('Failed to create project. Please try again.');
     },
   });
 

--- a/apps/client/src/pages/AccountSettings.tsx
+++ b/apps/client/src/pages/AccountSettings.tsx
@@ -8,8 +8,10 @@ import {
   HandleProjectInvitationRequestDTO,
 } from '@/types/project';
 import { axiosInstance } from '@/lib/axios.ts';
+import { useToast } from '@/lib/useToast';
 
 function AccountSettings() {
+  const toast = useToast();
   const queryClient = useQueryClient();
   const { data: invitations } = useSuspenseQuery({
     queryKey: ['project', 'invitations'],
@@ -34,11 +36,12 @@ function AccountSettings() {
       await axiosInstance.patch(`/project/${projectId}/invite`, payload);
     },
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
       queryClient.invalidateQueries({ queryKey: ['project', 'invitations'] });
+      toast.success('Invitation responded successfully');
     },
-    onError: (error) => {
-      alert('Failed to respond to invitation');
-      console.log('Failed to respond to invitation', error);
+    onError: () => {
+      toast.error('Failed to respond to invitation. Please try again.');
     },
   });
 

--- a/apps/client/src/pages/ProjectOverview.tsx
+++ b/apps/client/src/pages/ProjectOverview.tsx
@@ -1,0 +1,199 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { useParams } from '@tanstack/react-router';
+import { User } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Progress } from '@/components/ui/progress';
+import { axiosInstance } from '@/lib/axios';
+
+interface GetOverviewResponseDto {
+  status: number;
+  message: string;
+  result: {
+    totalTasks: number;
+    sections: {
+      id: number;
+      title: string;
+      count: number;
+    }[];
+  };
+}
+
+interface GetWorkloadResponseDto {
+  status: number;
+  message: string;
+  result: {
+    totalTasks: number;
+    users: {
+      id: number;
+      username: string;
+      profileImage: string;
+      count: number;
+    }[];
+  };
+}
+
+// TODO: suspense fallback 만들어야함
+// TODO: status overview, burndown chart, ui 작업 필요
+function ProjectOverview() {
+  const { project } = useParams({ from: '/_auth/$project' });
+
+  const { data: overview } = useSuspenseQuery({
+    queryKey: ['project', project, 'overview'],
+    queryFn: async () => {
+      try {
+        const overview = await axiosInstance.get<GetOverviewResponseDto>(
+          `/project/${project}/overview`
+        );
+        return overview.data.result;
+      } catch {
+        throw new Error('Failed to fetch overview');
+      }
+    },
+  });
+
+  const { data: workload } = useSuspenseQuery({
+    queryKey: ['project', project, 'workload'],
+    queryFn: async () => {
+      try {
+        const workload = await axiosInstance.get<GetWorkloadResponseDto>(
+          `/project/${project}/workload`
+        );
+        return workload.data.result;
+      } catch {
+        throw new Error('Failed to fetch workload');
+      }
+    },
+  });
+
+  return (
+    <section className="px-6 py-6">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <Card className="h-[400px] overflow-y-auto bg-white">
+          <CardHeader>
+            <CardTitle className="text-xl">Status overview</CardTitle>
+            <CardDescription className="text-gray-500">
+              View your project&apos;s overall progress.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ul>
+              {overview.sections.map((section) => (
+                <li key={section.id} className="flex items-center gap-2">
+                  <span>{section.title}</span>
+                  <span className="text-gray-500">{section.count}</span>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+
+        <Card className="h-[400px] overflow-y-auto bg-white">
+          <CardHeader>
+            <CardTitle className="text-xl">Team Workload</CardTitle>
+            <CardDescription className="text-gray-500">
+              View your team&apos;s current workload at a glance.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-[150px]">Assignee</TableHead>
+                  <TableHead>Work distribution</TableHead>
+                  <TableHead className="text-right">Count</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                <TableRow className="border-0">
+                  <TableCell className="flex items-center gap-2">
+                    <Avatar className="h-6 w-6 border">
+                      <User size={24} />
+                    </Avatar>
+                    Unassigned
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      <Progress
+                        value={
+                          workload.totalTasks > 0
+                            ? ((workload.totalTasks -
+                                workload.users.reduce((acc, cur) => acc + cur.count, 0)) /
+                                workload.totalTasks) *
+                              100
+                            : 0
+                        }
+                      />
+                      {workload.totalTasks > 0
+                        ? (
+                            ((workload.totalTasks -
+                              workload.users.reduce((acc, cur) => acc + cur.count, 0)) /
+                              workload.totalTasks) *
+                            100
+                          ).toFixed(0)
+                        : 0}
+                      %
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {workload.totalTasks > 0
+                      ? workload.totalTasks -
+                        workload.users.reduce((acc, cur) => acc + cur.count, 0)
+                      : 0}
+                  </TableCell>
+                </TableRow>
+                {workload.users.map((user) => (
+                  <TableRow key={user.id} className="border-0">
+                    <TableCell className="flex items-center gap-2">
+                      <Avatar className="h-6 w-6 border">
+                        <AvatarImage src={user.profileImage} />
+                        <AvatarFallback>
+                          <div className="h-full w-full bg-gradient-to-br from-purple-600 via-fuchsia-500 to-pink-500" />
+                        </AvatarFallback>
+                      </Avatar>
+                      {user.username}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <Progress
+                          value={
+                            workload.totalTasks > 0 ? (user.count / workload.totalTasks) * 100 : 0
+                          }
+                        />
+                        {workload.totalTasks > 0
+                          ? ((user.count / workload.totalTasks) * 100).toFixed(0)
+                          : 0}
+                        %
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right">{user.count}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+
+        <Card className="h-[400px] bg-white">
+          <CardHeader>
+            <CardTitle className="text-xl">Burndown chart</CardTitle>
+            <CardDescription className="text-gray-500">
+              Track your project&apos;s progress over time
+            </CardDescription>
+          </CardHeader>
+          <CardContent>번다운차트</CardContent>
+        </Card>
+      </div>
+    </section>
+  );
+}
+
+export default ProjectOverview;

--- a/apps/client/src/pages/ProjectOverview.tsx
+++ b/apps/client/src/pages/ProjectOverview.tsx
@@ -1,6 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
-import { User } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
@@ -113,43 +112,6 @@ function ProjectOverview() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                <TableRow className="border-0">
-                  <TableCell className="flex items-center gap-2">
-                    <Avatar className="h-6 w-6 border">
-                      <User size={24} />
-                    </Avatar>
-                    Unassigned
-                  </TableCell>
-                  <TableCell>
-                    <div className="flex items-center gap-2">
-                      <Progress
-                        value={
-                          workload.totalTasks > 0
-                            ? ((workload.totalTasks -
-                                workload.users.reduce((acc, cur) => acc + cur.count, 0)) /
-                                workload.totalTasks) *
-                              100
-                            : 0
-                        }
-                      />
-                      {workload.totalTasks > 0
-                        ? (
-                            ((workload.totalTasks -
-                              workload.users.reduce((acc, cur) => acc + cur.count, 0)) /
-                              workload.totalTasks) *
-                            100
-                          ).toFixed(0)
-                        : 0}
-                      %
-                    </div>
-                  </TableCell>
-                  <TableCell className="text-right">
-                    {workload.totalTasks > 0
-                      ? workload.totalTasks -
-                        workload.users.reduce((acc, cur) => acc + cur.count, 0)
-                      : 0}
-                  </TableCell>
-                </TableRow>
                 {workload.users.map((user) => (
                   <TableRow key={user.id} className="border-0">
                     <TableCell className="flex items-center gap-2">
@@ -164,14 +126,17 @@ function ProjectOverview() {
                     <TableCell>
                       <div className="flex items-center gap-2">
                         <Progress
+                          className="flex-1"
                           value={
                             workload.totalTasks > 0 ? (user.count / workload.totalTasks) * 100 : 0
                           }
                         />
-                        {workload.totalTasks > 0
-                          ? ((user.count / workload.totalTasks) * 100).toFixed(0)
-                          : 0}
-                        %
+                        <span className="w-10">
+                          {workload.totalTasks > 0
+                            ? ((user.count / workload.totalTasks) * 100).toFixed(0)
+                            : 0}
+                          %
+                        </span>
                       </div>
                     </TableCell>
                     <TableCell className="text-right">{user.count}</TableCell>

--- a/apps/client/src/pages/ProjectSettings.tsx
+++ b/apps/client/src/pages/ProjectSettings.tsx
@@ -10,6 +10,7 @@ import { Input } from '@/components/ui/input';
 import { GetProjectMembersResponseDTO, InviteProjectMemberRequestDTO } from '@/types/project';
 import { axiosInstance } from '@/lib/axios.ts';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { useToast } from '@/lib/useToast';
 
 const formSchema = z.object({
   username: z
@@ -21,6 +22,7 @@ const formSchema = z.object({
 function ProjectSettings() {
   const queryClient = useQueryClient();
   const { project } = useParams({ from: '/_auth/$project/settings' });
+  const toast = useToast();
 
   const { data: members } = useSuspenseQuery({
     queryKey: ['project', project, 'members'],
@@ -42,10 +44,10 @@ function ProjectSettings() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['project', project, 'members'] });
+      toast.success('Member invited successfully.');
     },
-    onError: (error) => {
-      alert('Failed to invite member');
-      console.log('Failed to invite member', error);
+    onError: () => {
+      toast.error('Failed to invite member.');
     },
   });
 

--- a/apps/client/src/pages/ProjectSettings.tsx
+++ b/apps/client/src/pages/ProjectSettings.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input';
 import { GetProjectMembersResponseDTO, InviteProjectMemberRequestDTO } from '@/types/project';
 import { axiosInstance } from '@/lib/axios.ts';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 
 const formSchema = z.object({
   username: z
@@ -75,7 +76,12 @@ function ProjectSettings() {
                 className="flex items-center justify-between rounded-lg border bg-[#fafafa] p-4"
               >
                 <div className="flex items-center space-x-4">
-                  <div className="h-8 w-8 rounded-full bg-[#2ecc71]" />
+                  <Avatar className="h-8 w-8 rounded-full border">
+                    <AvatarImage src={member.profileImage} className="object-cover" alt="Avatar" />
+                    <AvatarFallback>
+                      <div className="h-full w-full bg-gradient-to-br from-purple-600 via-fuchsia-500 to-pink-500" />
+                    </AvatarFallback>
+                  </Avatar>
                   <div>
                     <p className="font-medium">{member.username}</p>
                     <p className="text-sm text-gray-500">

--- a/apps/client/src/routes/__root.tsx
+++ b/apps/client/src/routes/__root.tsx
@@ -1,6 +1,7 @@
 import { createRootRouteWithContext, Outlet } from '@tanstack/react-router';
 import { QueryClient } from '@tanstack/react-query';
 import { AuthContextValue } from '@/features/auth/AuthProvider.tsx';
+import { Toaster } from '@/components/ui/sonner.tsx';
 
 interface RouterContext {
   auth: AuthContextValue;
@@ -8,5 +9,10 @@ interface RouterContext {
 }
 
 export const Route = createRootRouteWithContext<RouterContext>()({
-  component: () => <Outlet />,
+  component: () => (
+    <>
+      <Outlet />
+      <Toaster position="bottom-left" />
+    </>
+  ),
 });

--- a/apps/client/src/routes/_auth.$project.board.tsx
+++ b/apps/client/src/routes/_auth.$project.board.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Outlet } from '@tanstack/react-router';
 import Board from '@/pages/Board.tsx';
 import { TasksResponse } from '@/components/KanbanBoard.tsx';
 import { axiosInstance } from '@/lib/axios.ts';
+import PlanningPokerFloatingButton from '@/components/PlanningPokerFloatingButton';
 
 export const Route = createFileRoute('/_auth/$project/board')({
   loader: ({ context: { queryClient }, params: { project: projectId } }) => {
@@ -20,6 +21,7 @@ export const Route = createFileRoute('/_auth/$project/board')({
   component: () => (
     <>
       <Board />
+      <PlanningPokerFloatingButton />
       <Outlet />
     </>
   ),

--- a/apps/client/src/routes/_auth.$project.index.tsx
+++ b/apps/client/src/routes/_auth.$project.index.tsx
@@ -1,16 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
-import PlanningPokerFloatingButton from '@/components/PlanningPokerFloatingButton';
+import ProjectOverview from '@/pages/ProjectOVerview';
 
 export const Route = createFileRoute('/_auth/$project/')({
-  component: RouteComponent,
+  component: ProjectOverview,
 });
-
-function RouteComponent() {
-  const { project } = Route.useParams();
-  return (
-    <div>
-      안녕하세요, {project} 대시보드 페이지
-      <PlanningPokerFloatingButton />
-    </div>
-  );
-}

--- a/apps/client/src/routes/_auth.$project.index.tsx
+++ b/apps/client/src/routes/_auth.$project.index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
-import ProjectOverview from '@/pages/ProjectOVerview';
+import ProjectOverview from '@/pages/ProjectOverview';
 
 export const Route = createFileRoute('/_auth/$project/')({
   component: ProjectOverview,

--- a/apps/client/src/routes/_auth.tsx
+++ b/apps/client/src/routes/_auth.tsx
@@ -14,7 +14,6 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { axiosInstance } from '@/lib/axios.ts';
 import { useAuth } from '@/features/auth/useAuth.ts';
-import { Toaster } from '@/components/ui/sonner.tsx';
 import {
   Dialog,
   DialogContent,
@@ -301,7 +300,6 @@ function AuthLayout() {
         </DialogContent>
       </Dialog>
       <Outlet />
-      <Toaster position="bottom-left" />
     </div>
   );
 }

--- a/apps/client/src/types/project.ts
+++ b/apps/client/src/types/project.ts
@@ -19,6 +19,7 @@ export interface ProjectMember {
   id: number;
   username: string;
   role: string;
+  profileImage: string;
 }
 
 export interface GetProjectMembersResponseDTO {


### PR DESCRIPTION
## 관련 이슈 번호

#179 

## 작업 내용

- 대시보드 워크로드 뷰, 기능 구성했습니다.
- 여러 사소한 작업
  - 팀멤버 프로필 이미지 추가
  - 프로젝트 초대와 응답에 토스트 메시지 추가
  - 회원가입 실패시 토스트 메시지 추가
  - 프로젝트 생성 관련 토스트 메시지 추가
  - 이제 프로젝트 목록 눌러도 이동됩니다!
  - 플래닝 포커 버튼 칸반뷰로 이동했습니다.

## 스크린샷

<img width="1728" alt="Screenshot 2024-11-28 at 12 51 03 AM" src="https://github.com/user-attachments/assets/cd2a9221-28ff-40cc-b6a4-383c9e33454f">
