### PR TITLE
각각의 쿼리에 대해 useSuspenseQuries로 수정

### DIFF
--- a/apps/client/src/pages/ProjectOverview.tsx
+++ b/apps/client/src/pages/ProjectOverview.tsx
@@ -1,4 +1,4 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQueries } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
 import { Bar, BarChart, Cell, XAxis, Label, Pie, PieChart } from 'recharts';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -66,50 +66,51 @@ const overviewConfig = {
   Done: { label: 'Done', color: '#00B67A' },
 } satisfies ChartConfig;
 
-// TODO: suspense fallback 만들어야함
 function ProjectOverview() {
   const { project } = useParams({ from: '/_auth/$project' });
 
-  const { data: overview } = useSuspenseQuery({
-    queryKey: ['project', project, 'overview'],
-    queryFn: async () => {
-      try {
-        const overview = await axiosInstance.get<GetOverviewResponseDto>(
-          `/project/${project}/overview`
-        );
-        return overview.data.result;
-      } catch {
-        throw new Error('Failed to fetch overview');
-      }
-    },
-  });
-
-  const { data: workload } = useSuspenseQuery({
-    queryKey: ['project', project, 'workload'],
-    queryFn: async () => {
-      try {
-        const workload = await axiosInstance.get<GetWorkloadResponseDto>(
-          `/project/${project}/workload`
-        );
-        return workload.data.result;
-      } catch {
-        throw new Error('Failed to fetch workload');
-      }
-    },
-  });
-
-  const { data: priority } = useSuspenseQuery({
-    queryKey: ['project', project, 'priority'],
-    queryFn: async () => {
-      try {
-        const priority = await axiosInstance.get<GetPriorityResponseDto>(
-          `/project/${project}/priority`
-        );
-        return priority.data.result;
-      } catch {
-        throw new Error('Failed to fetch priority');
-      }
-    },
+  const [{ data: overview }, { data: workload }, { data: priority }] = useSuspenseQueries({
+    queries: [
+      {
+        queryKey: ['project', project, 'overview'],
+        queryFn: async () => {
+          try {
+            const overview = await axiosInstance.get<GetOverviewResponseDto>(
+              `/project/${project}/overview`
+            );
+            return overview.data.result;
+          } catch {
+            throw new Error('Failed to fetch overview');
+          }
+        },
+      },
+      {
+        queryKey: ['project', project, 'workload'],
+        queryFn: async () => {
+          try {
+            const workload = await axiosInstance.get<GetWorkloadResponseDto>(
+              `/project/${project}/workload`
+            );
+            return workload.data.result;
+          } catch {
+            throw new Error('Failed to fetch workload');
+          }
+        },
+      },
+      {
+        queryKey: ['project', project, 'priority'],
+        queryFn: async () => {
+          try {
+            const priority = await axiosInstance.get<GetPriorityResponseDto>(
+              `/project/${project}/priority`
+            );
+            return priority.data.result;
+          } catch {
+            throw new Error('Failed to fetch priority');
+          }
+        },
+      },
+    ],
   });
 
   const overviewData = overview.sections.map((section) => ({

--- a/apps/client/src/routes/_auth.$project.index.tsx
+++ b/apps/client/src/routes/_auth.$project.index.tsx
@@ -1,6 +1,17 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { Suspense } from 'react';
 import ProjectOverview from '@/pages/ProjectOverview';
 
 export const Route = createFileRoute('/_auth/$project/')({
-  component: ProjectOverview,
+  component: () => (
+    <Suspense fallback={<div>Loading...</div>}>
+      <ProjectOverview />
+    </Suspense>
+  ),
+  errorComponent: () => (
+    <div>
+      <h2>Failed to load overview</h2>
+      <p>Sorry, an unexpected error occured.</p>
+    </div>
+  ),
 });


### PR DESCRIPTION
## 관련 이슈 번호

#222 

## 작업 내용

- 3개의 쿼리에 대해 병렬로 요청을 수행할 수 있도록 수정했습니다.

## 스크린샷

- before

<img width="143" alt="Screenshot 2024-12-02 at 6 45 14 PM" src="https://github.com/user-attachments/assets/42fba3ea-23c6-40fa-b777-7fd358d98282">

- after

<img width="106" alt="Screenshot 2024-12-02 at 7 44 38 PM" src="https://github.com/user-attachments/assets/a55e613c-b0cb-43f2-9344-19b94fbb70d6">
