### PR TITLE
[Refactor] 칸반 보드 컴포넌트 분리 및 드래그앤드롭 로직 분리

### DIFF
--- a/apps/client/src/features/project/board/components/KanbanBoard.tsx
+++ b/apps/client/src/features/project/board/components/KanbanBoard.tsx
@@ -1,20 +1,11 @@
-import { DragEvent } from 'react';
-import { Link } from '@tanstack/react-router';
-import { motion, AnimatePresence } from 'framer-motion';
-import { PanelLeftOpen } from 'lucide-react';
-import { Button } from '@/components/ui/button.tsx';
-import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card.tsx';
-import { cn } from '@/lib/utils.ts';
-import { Badge } from '@/components/ui/badge.tsx';
+import { AnimatePresence } from 'framer-motion';
 import { useToast } from '@/lib/useToast.tsx';
 import { useBoardMutations } from '@/features/project/board/useBoardMutations.ts';
-import { AssigneeAvatars } from '@/features/project/board/components/AssigneeAvatars.tsx';
 import { calculatePosition, findDiff, findTask } from '@/features/project/board/utils.ts';
-import { TaskTextarea } from '@/features/project/board/components/TaskTextarea.tsx';
 import { useBoardStore } from '@/features/project/board/useBoardStore.ts';
-import { SubtaskProgress } from '@/features/project/board/components/SubtaskProgress.tsx';
 import { useDragAndDrop } from '@/features/project/board/useDragAndDrop.ts';
 import { BoardSection } from '@/features/project/board/components/KanbanSection.tsx';
+import { TaskCard } from '@/features/project/board/components/KanbanTask.tsx';
 
 interface KanbanBoardProps {
   projectId: number;
@@ -24,7 +15,11 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   const { sections, updateTaskPosition, updateTaskTitle, restoreState } = useBoardStore();
 
   const toast = useToast();
-  const mutations = useBoardMutations(projectId);
+
+  const {
+    updateTitle: { mutate: updateTitleMutate },
+    updatePosition: { mutate: updatePositionMutate },
+  } = useBoardMutations(projectId);
 
   const onDrop = (sectionId: number, taskId: number) => {
     const targetSection = sections.find((section) => section.id === sectionId);
@@ -39,7 +34,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
 
     updateTaskPosition(sectionId, taskId, position);
 
-    mutations.updatePosition.mutate(
+    updatePositionMutate(
       {
         event: 'UPDATE_POSITION',
         sectionId,
@@ -70,43 +65,36 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
 
     const diff = findDiff(task.title, newTitle);
 
+    const deletePayload = {
+      event: 'DELETE_TITLE' as const,
+      taskId,
+      title: {
+        position: diff.position,
+        content: diff.originalContent,
+        length: diff.originalContent.length,
+      },
+    };
+
+    const insertPayload = {
+      event: 'INSERT_TITLE' as const,
+      taskId,
+      title: {
+        position: diff.position,
+        content: diff.content,
+        length: diff.content.length,
+      },
+    };
+
     if (diff.originalContent.length > 0) {
-      mutations.updateTitle.mutate(
-        {
-          event: 'DELETE_TITLE',
-          taskId,
-          title: {
-            position: diff.position,
-            content: diff.originalContent,
-            length: diff.originalContent.length,
-          },
-        },
-        {
-          onSuccess: () => {
-            if (diff.content.length > 0) {
-              mutations.updateTitle.mutate({
-                event: 'INSERT_TITLE',
-                taskId,
-                title: {
-                  position: diff.position,
-                  content: diff.content,
-                  length: diff.content.length,
-                },
-              });
-            }
-          },
-        }
-      );
-    } else if (diff.content.length > 0) {
-      mutations.updateTitle.mutate({
-        event: 'INSERT_TITLE',
-        taskId,
-        title: {
-          position: diff.position,
-          content: diff.content,
-          length: diff.content.length,
+      updateTitleMutate(deletePayload, {
+        onSuccess: () => {
+          if (diff.content.length > 0) {
+            updateTitleMutate(insertPayload);
+          }
         },
       });
+    } else if (diff.content.length > 0) {
+      updateTitleMutate(insertPayload);
     }
 
     updateTaskTitle(taskId, newTitle);
@@ -124,74 +112,16 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
             onDragOver={(e) => handleDragOver(e, section.id)}
           >
             {section.tasks.map((task) => (
-              <motion.div
+              <TaskCard
                 key={task.id}
-                layout
-                layoutId={task.id.toString()}
-                draggable
-                initial={{ opacity: 1, zIndex: 1 }}
-                animate={{
-                  zIndex: task.id === belowTaskId ? 50 : 1,
-                  scale: task.id === belowTaskId ? 1.02 : 1,
-                }}
-                transition={{
-                  layout: { duration: 0.3 },
-                  scale: { duration: 0.2 },
-                }}
-                style={{ position: 'relative' }}
-                onDragStart={(e) => handleDragStart(e as unknown as DragEvent, section.id, task.id)}
-                onDrop={(e) => handleDrop(e, section.id)}
-                onDragOver={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  handleDragOver(e, section.id, task.id);
-                }}
+                task={task}
+                isBelow={task.id === belowTaskId}
+                onDragStart={(e) => handleDragStart(e, section.id, task.id)}
+                onDragOver={(e) => handleDragOver(e, section.id, task.id)}
                 onDragLeave={handleDragLeave}
-              >
-                <Card
-                  className={cn(
-                    'w-56 border bg-white transition-all duration-300 md:w-80',
-                    task.id === belowTaskId && 'border-2 border-blue-400',
-                    'hover:shadow-md'
-                  )}
-                >
-                  <CardHeader className="flex flex-row items-start gap-2 space-y-0">
-                    <TaskTextarea
-                      taskId={task.id}
-                      initialTitle={task.title}
-                      onTitleChange={handleTitleChange}
-                    />
-                    <Button
-                      variant="ghost"
-                      type="button"
-                      asChild
-                      className="hover:text-primary px-2 hover:bg-transparent"
-                    >
-                      <Link to={`/${projectId}/board/${task.id}`} className="p-0">
-                        <PanelLeftOpen className="h-6 w-6" />
-                      </Link>
-                    </Button>
-                  </CardHeader>
-                  <CardContent className="flex items-end justify-between">
-                    <div className="flex flex-wrap gap-1">
-                      {task.labels.map((label) => (
-                        <Badge key={label.id} style={{ backgroundColor: label.color }}>
-                          {label.name}
-                        </Badge>
-                      ))}
-                    </div>
-                    <AssigneeAvatars assignees={task.assignees} />
-                  </CardContent>
-                  {task.subtasks.total > 0 && (
-                    <CardFooter className="flex items-center justify-between space-y-0">
-                      <SubtaskProgress
-                        total={task.subtasks.total}
-                        completed={task.subtasks.completed}
-                      />
-                    </CardFooter>
-                  )}
-                </Card>
-              </motion.div>
+                onDrop={(e) => handleDrop(e, section.id)}
+                onTitleChange={handleTitleChange}
+              />
             ))}
           </BoardSection>
         ))}

--- a/apps/client/src/features/project/board/components/KanbanBoard.tsx
+++ b/apps/client/src/features/project/board/components/KanbanBoard.tsx
@@ -1,21 +1,7 @@
-import { ReactNode, DragEvent } from 'react';
+import { DragEvent } from 'react';
 import { Link } from '@tanstack/react-router';
 import { motion, AnimatePresence } from 'framer-motion';
-import { HamburgerMenuIcon, PlusIcon } from '@radix-ui/react-icons';
 import { PanelLeftOpen } from 'lucide-react';
-
-import {
-  Section,
-  SectionContent,
-  SectionFooter,
-  SectionHeader,
-  SectionTitle,
-} from '@/components/ui/section.tsx';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu.tsx';
 import { Button } from '@/components/ui/button.tsx';
 import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card.tsx';
 import { cn } from '@/lib/utils.ts';
@@ -28,14 +14,14 @@ import { TaskTextarea } from '@/features/project/board/components/TaskTextarea.t
 import { useBoardStore } from '@/features/project/board/useBoardStore.ts';
 import { SubtaskProgress } from '@/features/project/board/components/SubtaskProgress.tsx';
 import { useDragAndDrop } from '@/features/project/board/useDragAndDrop.ts';
+import { BoardSection } from '@/features/project/board/components/KanbanSection.tsx';
 
 interface KanbanBoardProps {
   projectId: number;
 }
 
 export function KanbanBoard({ projectId }: KanbanBoardProps) {
-  const { sections, updateTaskPosition, updateTaskTitle, createTask, restoreState } =
-    useBoardStore();
+  const { sections, updateTaskPosition, updateTaskTitle, restoreState } = useBoardStore();
 
   const toast = useToast();
   const mutations = useBoardMutations(projectId);
@@ -76,7 +62,6 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
     handleDragOver,
     handleDragLeave,
     handleDrop,
-    handleDragEnd,
   } = useDragAndDrop(onDrop);
 
   const handleTitleChange = (taskId: number, newTitle: string) => {
@@ -127,183 +112,90 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
     updateTaskTitle(taskId, newTitle);
   };
 
-  const handleCreateTask = (sectionId: number) => {
-    const section = sections.find((s) => s.id === sectionId);
-    if (!section) return;
-
-    const position = calculatePosition(section.tasks, -1);
-
-    mutations.createTask.mutate(
-      {
-        event: 'CREATE_TASK',
-        sectionId,
-        position,
-      },
-      {
-        onSuccess: (response) => {
-          createTask(sectionId, {
-            id: response.id,
-            title: '',
-            sectionId,
-            position,
-            assignees: [],
-            labels: [],
-            subtasks: { total: 0, completed: 0 },
-          });
-        },
-        onError: () => {
-          toast.error('Failed to create task');
-        },
-      }
-    );
-  };
-
   return (
     <div className="spazce-x-2 flex h-[calc(100vh-110px)] gap-2 overflow-x-auto p-4">
       <AnimatePresence mode="popLayout">
         {sections.map((section) => (
-          <Section
+          <BoardSection
             key={section.id}
-            className={cn(
-              'flex h-full w-[352px] flex-shrink-0 flex-col items-center',
-              'bg-transparent',
-              section.id === belowSectionId && belowTaskId === -1 && 'border-2 border-blue-400'
-            )}
+            section={section}
+            isBelow={section.id === belowSectionId}
+            onDrop={(e) => handleDrop(e, section.id)}
+            onDragOver={(e) => handleDragOver(e, section.id)}
           >
-            <SectionHeader className="flex w-full items-center justify-between gap-2 space-y-0">
-              <div className="flex items-center gap-2">
-                <SectionTitle className="text-xl">{section.name}</SectionTitle>
-                <SectionCount>{section.tasks.length}</SectionCount>
-              </div>
-              <SectionDropdownMenu>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  className="text-blac hover:text-primary w-full border-none px-0 hover:bg-white"
-                  onClick={() => handleCreateTask(section.id)}
-                >
-                  <PlusIcon />
-                  Add Task
-                </Button>
-              </SectionDropdownMenu>
-            </SectionHeader>
-            <SectionContent
-              key={section.id}
-              className="flex w-full flex-1 flex-col items-center gap-2 overflow-y-auto pt-1"
-              onDragOver={(e) => handleDragOver(e, section.id)}
-              onDragLeave={handleDragLeave}
-              onDrop={(e) => handleDrop(e, section.id)}
-              onDragEnd={handleDragEnd}
-            >
-              {section.tasks.map((task) => (
-                <motion.div
-                  key={task.id}
-                  layout
-                  layoutId={task.id.toString()}
-                  draggable
-                  initial={{ opacity: 1, zIndex: 1 }}
-                  animate={{
-                    zIndex: task.id === belowTaskId ? 50 : 1,
-                    scale: task.id === belowTaskId ? 1.02 : 1,
-                  }}
-                  transition={{
-                    layout: { duration: 0.3 },
-                    scale: { duration: 0.2 },
-                  }}
-                  style={{ position: 'relative' }}
-                  onDragStart={(e) =>
-                    handleDragStart(e as unknown as DragEvent, section.id, task.id)
-                  }
-                  onDrop={(e) => handleDrop(e, section.id)}
-                  onDragOver={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    handleDragOver(e, section.id, task.id);
-                  }}
-                  onDragLeave={handleDragLeave}
-                >
-                  <Card
-                    className={cn(
-                      'w-56 border bg-white transition-all duration-300 md:w-80',
-                      task.id === belowTaskId && 'border-2 border-blue-400',
-                      'hover:shadow-md'
-                    )}
-                  >
-                    <CardHeader className="flex flex-row items-start gap-2 space-y-0">
-                      <TaskTextarea
-                        taskId={task.id}
-                        initialTitle={task.title}
-                        onTitleChange={handleTitleChange}
-                      />
-                      <Button
-                        variant="ghost"
-                        type="button"
-                        asChild
-                        className="hover:text-primary px-2 hover:bg-transparent"
-                      >
-                        <Link to={`/${projectId}/board/${task.id}`} className="p-0">
-                          <PanelLeftOpen className="h-6 w-6" />
-                        </Link>
-                      </Button>
-                    </CardHeader>
-                    <CardContent className="flex items-end justify-between">
-                      <div className="flex flex-wrap gap-1">
-                        {task.labels.map((label) => (
-                          <Badge key={label.id} style={{ backgroundColor: label.color }}>
-                            {label.name}
-                          </Badge>
-                        ))}
-                      </div>
-                      <AssigneeAvatars assignees={task.assignees} />
-                    </CardContent>
-                    {task.subtasks.total > 0 && (
-                      <CardFooter className="flex items-center justify-between space-y-0">
-                        <SubtaskProgress
-                          total={task.subtasks.total}
-                          completed={task.subtasks.completed}
-                        />
-                      </CardFooter>
-                    )}
-                  </Card>
-                </motion.div>
-              ))}
-            </SectionContent>
-            <SectionFooter className="w-full">
-              <Button
-                variant="ghost"
-                className="w-full border-none px-0 text-black"
-                onClick={() => handleCreateTask(section.id)}
+            {section.tasks.map((task) => (
+              <motion.div
+                key={task.id}
+                layout
+                layoutId={task.id.toString()}
+                draggable
+                initial={{ opacity: 1, zIndex: 1 }}
+                animate={{
+                  zIndex: task.id === belowTaskId ? 50 : 1,
+                  scale: task.id === belowTaskId ? 1.02 : 1,
+                }}
+                transition={{
+                  layout: { duration: 0.3 },
+                  scale: { duration: 0.2 },
+                }}
+                style={{ position: 'relative' }}
+                onDragStart={(e) => handleDragStart(e as unknown as DragEvent, section.id, task.id)}
+                onDrop={(e) => handleDrop(e, section.id)}
+                onDragOver={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  handleDragOver(e, section.id, task.id);
+                }}
+                onDragLeave={handleDragLeave}
               >
-                <PlusIcon />
-                Add Task
-              </Button>
-            </SectionFooter>
-          </Section>
+                <Card
+                  className={cn(
+                    'w-56 border bg-white transition-all duration-300 md:w-80',
+                    task.id === belowTaskId && 'border-2 border-blue-400',
+                    'hover:shadow-md'
+                  )}
+                >
+                  <CardHeader className="flex flex-row items-start gap-2 space-y-0">
+                    <TaskTextarea
+                      taskId={task.id}
+                      initialTitle={task.title}
+                      onTitleChange={handleTitleChange}
+                    />
+                    <Button
+                      variant="ghost"
+                      type="button"
+                      asChild
+                      className="hover:text-primary px-2 hover:bg-transparent"
+                    >
+                      <Link to={`/${projectId}/board/${task.id}`} className="p-0">
+                        <PanelLeftOpen className="h-6 w-6" />
+                      </Link>
+                    </Button>
+                  </CardHeader>
+                  <CardContent className="flex items-end justify-between">
+                    <div className="flex flex-wrap gap-1">
+                      {task.labels.map((label) => (
+                        <Badge key={label.id} style={{ backgroundColor: label.color }}>
+                          {label.name}
+                        </Badge>
+                      ))}
+                    </div>
+                    <AssigneeAvatars assignees={task.assignees} />
+                  </CardContent>
+                  {task.subtasks.total > 0 && (
+                    <CardFooter className="flex items-center justify-between space-y-0">
+                      <SubtaskProgress
+                        total={task.subtasks.total}
+                        completed={task.subtasks.completed}
+                      />
+                    </CardFooter>
+                  )}
+                </Card>
+              </motion.div>
+            ))}
+          </BoardSection>
         ))}
       </AnimatePresence>
     </div>
-  );
-}
-
-function SectionCount({ children }: { children: ReactNode }) {
-  return (
-    <span className="mt-0 flex h-6 w-6 items-center justify-center rounded-lg border border-gray-400 text-gray-600">
-      {children}
-    </span>
-  );
-}
-
-function SectionDropdownMenu({ children }: { children: ReactNode }) {
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger>
-        <Button variant="ghost" className="hover:text-primary h-6 w-6 hover:bg-transparent">
-          <HamburgerMenuIcon className="h-6 w-6" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="gap-1 bg-white p-0">
-        {children}
-      </DropdownMenuContent>
-    </DropdownMenu>
   );
 }

--- a/apps/client/src/features/project/board/components/KanbanBoard.tsx
+++ b/apps/client/src/features/project/board/components/KanbanBoard.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState, DragEvent } from 'react';
+import { ReactNode, DragEvent } from 'react';
 import { Link } from '@tanstack/react-router';
 import { motion, AnimatePresence } from 'framer-motion';
 import { HamburgerMenuIcon, PlusIcon } from '@radix-ui/react-icons';
@@ -27,19 +27,27 @@ import { calculatePosition, findDiff, findTask } from '@/features/project/board/
 import { TaskTextarea } from '@/features/project/board/components/TaskTextarea.tsx';
 import { useBoardStore } from '@/features/project/board/useBoardStore.ts';
 import { SubtaskProgress } from '@/features/project/board/components/SubtaskProgress.tsx';
+import { useDragAndDrop } from '@/features/project/board/useDragAndDrop.ts';
 
 interface KanbanBoardProps {
   projectId: number;
 }
 
 export function KanbanBoard({ projectId }: KanbanBoardProps) {
-  const { sections } = useBoardStore();
-  const { updateTaskPosition, updateTaskTitle, createTask, restoreState } = useBoardStore();
+  const { sections, updateTaskPosition, updateTaskTitle, createTask, restoreState } =
+    useBoardStore();
 
   const toast = useToast();
   const mutations = useBoardMutations(projectId);
-  const [belowSectionId, setBelowSectionId] = useState<number>(-1);
-  const [belowTaskId, setBelowTaskId] = useState<number>(-1);
+
+  const {
+    belowSectionId,
+    belowTaskId,
+    handleDragStart,
+    handleDragOver,
+    handleDragLeave,
+    handleDragEnd,
+  } = useDragAndDrop();
 
   const handleTitleChange = (taskId: number, newTitle: string) => {
     const task = findTask(sections, taskId);
@@ -96,8 +104,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
     const taskId = Number(event.dataTransfer.getData('taskId'));
 
     if (taskId === belowTaskId) {
-      setBelowTaskId(-1);
-      setBelowSectionId(-1);
+      handleDragEnd();
       return;
     }
 
@@ -113,9 +120,6 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
 
     updateTaskPosition(sectionId, taskId, position);
 
-    setBelowTaskId(-1);
-    setBelowSectionId(-1);
-
     mutations.updatePosition.mutate(
       {
         event: 'UPDATE_POSITION',
@@ -130,6 +134,8 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
         },
       }
     );
+
+    handleDragEnd();
   };
 
   const handleCreateTask = (sectionId: number) => {
@@ -163,162 +169,129 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
     );
   };
 
-  const handleDragStart = (event: DragEvent<HTMLDivElement>, sectionId: number, taskId: number) => {
-    event.dataTransfer.setData('taskId', taskId.toString());
-    event.dataTransfer.setData('sectionId', sectionId.toString());
-  };
-
-  const handleDragEnd = () => {
-    setBelowTaskId(-1);
-    setBelowSectionId(-1);
-  };
-
-  const handleDragOver = (e: DragEvent<HTMLDivElement>, sectionId: number, taskId?: number) => {
-    e.preventDefault();
-    setBelowSectionId(sectionId);
-
-    if (!taskId) {
-      setBelowTaskId(-1);
-      return;
-    }
-
-    setBelowTaskId(taskId);
-  };
-
-  const handleDragLeave = () => {
-    setBelowTaskId(-1);
-    setBelowSectionId(-1);
-  };
-
   return (
-    <div className="relative h-full overflow-hidden">
-      <div className="spazce-x-2 flex h-[calc(100vh-110px)] gap-2 overflow-x-auto p-4">
-        <AnimatePresence mode="popLayout">
-          {sections.map((section) => (
-            <Section
-              key={section.id}
-              className={cn(
-                'flex h-full w-[352px] flex-shrink-0 flex-col items-center',
-                'bg-transparent',
-                section.id === belowSectionId && belowTaskId === -1 && 'border-2 border-blue-400'
-              )}
-            >
-              <SectionHeader className="flex w-full items-center justify-between gap-2 space-y-0">
-                <div className="flex items-center gap-2">
-                  <SectionTitle className="text-xl">{section.name}</SectionTitle>
-                  <SectionCount>{section.tasks.length}</SectionCount>
-                </div>
-                <SectionDropdownMenu>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    className="text-blac hover:text-primary w-full border-none px-0 hover:bg-white"
-                    onClick={() => handleCreateTask(section.id)}
-                  >
-                    <PlusIcon />
-                    Add Task
-                  </Button>
-                </SectionDropdownMenu>
-              </SectionHeader>
-              <SectionContent
-                key={section.id}
-                className="flex w-full flex-1 flex-col items-center gap-2 overflow-y-auto pt-1"
-                onDragOver={(e) => handleDragOver(e, section.id)}
-                onDragLeave={handleDragLeave}
-                onDrop={(e) => handleDrop(e, section.id)}
-                onDragEnd={handleDragEnd}
-              >
-                {section.tasks.map((task) => (
-                  <motion.div
-                    key={task.id}
-                    layout
-                    layoutId={task.id.toString()}
-                    draggable
-                    initial={{ opacity: 1, zIndex: 1 }}
-                    animate={{
-                      zIndex: task.id === belowTaskId ? 50 : 1,
-                      scale: task.id === belowTaskId ? 1.02 : 1,
-                    }}
-                    transition={{
-                      layout: { duration: 0.3 },
-                      scale: { duration: 0.2 },
-                    }}
-                    style={{ position: 'relative' }}
-                    onDragStart={(e) =>
-                      handleDragStart(
-                        e as unknown as DragEvent<HTMLDivElement>,
-                        section.id,
-                        task.id
-                      )
-                    }
-                    onDrop={(e) => handleDrop(e, section.id)}
-                    onDragOver={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      handleDragOver(e, section.id, task.id);
-                    }}
-                    onDragLeave={handleDragLeave}
-                  >
-                    <Card
-                      className={cn(
-                        'w-56 border bg-white transition-all duration-300 md:w-80',
-                        task.id === belowTaskId && 'border-2 border-blue-400',
-                        'hover:shadow-md'
-                      )}
-                    >
-                      <CardHeader className="flex flex-row items-start gap-2 space-y-0">
-                        <TaskTextarea
-                          taskId={task.id}
-                          initialTitle={task.title}
-                          onTitleChange={handleTitleChange}
-                        />
-                        <Button
-                          variant="ghost"
-                          type="button"
-                          asChild
-                          className="hover:text-primary px-2 hover:bg-transparent"
-                        >
-                          <Link to={`/${projectId}/board/${task.id}`} className="p-0">
-                            <PanelLeftOpen className="h-6 w-6" />
-                          </Link>
-                        </Button>
-                      </CardHeader>
-                      <CardContent className="flex items-end justify-between">
-                        <div className="flex flex-wrap gap-1">
-                          {task.labels.map((label) => (
-                            <Badge key={label.id} style={{ backgroundColor: label.color }}>
-                              {label.name}
-                            </Badge>
-                          ))}
-                        </div>
-                        <AssigneeAvatars assignees={task.assignees} />
-                      </CardContent>
-                      {task.subtasks.total > 0 && (
-                        <CardFooter className="flex items-center justify-between space-y-0">
-                          <SubtaskProgress
-                            total={task.subtasks.total}
-                            completed={task.subtasks.completed}
-                          />
-                        </CardFooter>
-                      )}
-                    </Card>
-                  </motion.div>
-                ))}
-              </SectionContent>
-              <SectionFooter className="w-full">
+    <div className="spazce-x-2 flex h-[calc(100vh-110px)] gap-2 overflow-x-auto p-4">
+      <AnimatePresence mode="popLayout">
+        {sections.map((section) => (
+          <Section
+            key={section.id}
+            className={cn(
+              'flex h-full w-[352px] flex-shrink-0 flex-col items-center',
+              'bg-transparent',
+              section.id === belowSectionId && belowTaskId === -1 && 'border-2 border-blue-400'
+            )}
+          >
+            <SectionHeader className="flex w-full items-center justify-between gap-2 space-y-0">
+              <div className="flex items-center gap-2">
+                <SectionTitle className="text-xl">{section.name}</SectionTitle>
+                <SectionCount>{section.tasks.length}</SectionCount>
+              </div>
+              <SectionDropdownMenu>
                 <Button
+                  type="button"
                   variant="ghost"
-                  className="w-full border-none px-0 text-black"
+                  className="text-blac hover:text-primary w-full border-none px-0 hover:bg-white"
                   onClick={() => handleCreateTask(section.id)}
                 >
                   <PlusIcon />
                   Add Task
                 </Button>
-              </SectionFooter>
-            </Section>
-          ))}
-        </AnimatePresence>
-      </div>
+              </SectionDropdownMenu>
+            </SectionHeader>
+            <SectionContent
+              key={section.id}
+              className="flex w-full flex-1 flex-col items-center gap-2 overflow-y-auto pt-1"
+              onDragOver={(e) => handleDragOver(e, section.id)}
+              onDragLeave={handleDragLeave}
+              onDrop={(e) => handleDrop(e, section.id)}
+              onDragEnd={handleDragEnd}
+            >
+              {section.tasks.map((task) => (
+                <motion.div
+                  key={task.id}
+                  layout
+                  layoutId={task.id.toString()}
+                  draggable
+                  initial={{ opacity: 1, zIndex: 1 }}
+                  animate={{
+                    zIndex: task.id === belowTaskId ? 50 : 1,
+                    scale: task.id === belowTaskId ? 1.02 : 1,
+                  }}
+                  transition={{
+                    layout: { duration: 0.3 },
+                    scale: { duration: 0.2 },
+                  }}
+                  style={{ position: 'relative' }}
+                  onDragStart={(e) =>
+                    handleDragStart(e as unknown as DragEvent, section.id, task.id)
+                  }
+                  onDrop={(e) => handleDrop(e, section.id)}
+                  onDragOver={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    handleDragOver(e, section.id, task.id);
+                  }}
+                  onDragLeave={handleDragLeave}
+                >
+                  <Card
+                    className={cn(
+                      'w-56 border bg-white transition-all duration-300 md:w-80',
+                      task.id === belowTaskId && 'border-2 border-blue-400',
+                      'hover:shadow-md'
+                    )}
+                  >
+                    <CardHeader className="flex flex-row items-start gap-2 space-y-0">
+                      <TaskTextarea
+                        taskId={task.id}
+                        initialTitle={task.title}
+                        onTitleChange={handleTitleChange}
+                      />
+                      <Button
+                        variant="ghost"
+                        type="button"
+                        asChild
+                        className="hover:text-primary px-2 hover:bg-transparent"
+                      >
+                        <Link to={`/${projectId}/board/${task.id}`} className="p-0">
+                          <PanelLeftOpen className="h-6 w-6" />
+                        </Link>
+                      </Button>
+                    </CardHeader>
+                    <CardContent className="flex items-end justify-between">
+                      <div className="flex flex-wrap gap-1">
+                        {task.labels.map((label) => (
+                          <Badge key={label.id} style={{ backgroundColor: label.color }}>
+                            {label.name}
+                          </Badge>
+                        ))}
+                      </div>
+                      <AssigneeAvatars assignees={task.assignees} />
+                    </CardContent>
+                    {task.subtasks.total > 0 && (
+                      <CardFooter className="flex items-center justify-between space-y-0">
+                        <SubtaskProgress
+                          total={task.subtasks.total}
+                          completed={task.subtasks.completed}
+                        />
+                      </CardFooter>
+                    )}
+                  </Card>
+                </motion.div>
+              ))}
+            </SectionContent>
+            <SectionFooter className="w-full">
+              <Button
+                variant="ghost"
+                className="w-full border-none px-0 text-black"
+                onClick={() => handleCreateTask(section.id)}
+              >
+                <PlusIcon />
+                Add Task
+              </Button>
+            </SectionFooter>
+          </Section>
+        ))}
+      </AnimatePresence>
     </div>
   );
 }

--- a/apps/client/src/features/project/board/components/KanbanSection.tsx
+++ b/apps/client/src/features/project/board/components/KanbanSection.tsx
@@ -1,5 +1,4 @@
 import { ReactNode, DragEvent } from 'react';
-
 import { HamburgerMenuIcon, PlusIcon } from '@radix-ui/react-icons';
 import { useLoaderData } from '@tanstack/react-router';
 import {

--- a/apps/client/src/features/project/board/components/KanbanSection.tsx
+++ b/apps/client/src/features/project/board/components/KanbanSection.tsx
@@ -91,15 +91,7 @@ export function BoardSection({
           <SectionCount>{section.tasks.length}</SectionCount>
         </div>
         <SectionDropdownMenu>
-          <Button
-            type="button"
-            variant="ghost"
-            className="hover:text-primary w-full border-none px-0 text-black hover:bg-white"
-            onClick={handleCreateTask}
-          >
-            <PlusIcon />
-            Add Task
-          </Button>
+          <AddTaskButton onClick={handleCreateTask} />
         </SectionDropdownMenu>
       </SectionHeader>
 
@@ -112,14 +104,7 @@ export function BoardSection({
         {children}
       </SectionContent>
       <SectionFooter className="w-full">
-        <Button
-          variant="ghost"
-          className="w-full border-none px-0 text-black"
-          onClick={handleCreateTask}
-        >
-          <PlusIcon />
-          Add Task
-        </Button>
+        <AddTaskButton onClick={handleCreateTask} />
       </SectionFooter>
     </Section>
   );
@@ -145,5 +130,14 @@ function SectionDropdownMenu({ children }: { children: ReactNode }) {
         {children}
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+function AddTaskButton({ onClick }: { onClick: () => void }) {
+  return (
+    <Button variant="ghost" className="w-full border-none px-0 text-black" onClick={onClick}>
+      <PlusIcon />
+      Add Task
+    </Button>
   );
 }

--- a/apps/client/src/features/project/board/components/KanbanSection.tsx
+++ b/apps/client/src/features/project/board/components/KanbanSection.tsx
@@ -1,0 +1,149 @@
+import { ReactNode, DragEvent } from 'react';
+
+import { HamburgerMenuIcon, PlusIcon } from '@radix-ui/react-icons';
+import { useLoaderData } from '@tanstack/react-router';
+import {
+  Section,
+  SectionContent,
+  SectionFooter,
+  SectionHeader,
+  SectionTitle,
+} from '@/components/ui/section.tsx';
+import { Section as TSection } from '@/features/project/board/types.ts';
+import { cn } from '@/lib/utils.ts';
+import { Button } from '@/components/ui/button.tsx';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu.tsx';
+import { calculatePosition } from '@/features/project/board/utils.ts';
+import { useToast } from '@/lib/useToast.tsx';
+import { useBoardStore } from '@/features/project/board/useBoardStore.ts';
+import { useBoardMutations } from '@/features/project/board/useBoardMutations.ts';
+
+interface BoardSectionProps {
+  section: TSection;
+  isBelow: boolean;
+  onDrop: (e: DragEvent<HTMLElement>) => void;
+  onDragOver: (e: DragEvent<HTMLElement>) => void;
+  children: ReactNode;
+}
+
+export function BoardSection({
+  section,
+  isBelow,
+  onDrop,
+  onDragOver,
+  children,
+}: BoardSectionProps) {
+  const { projectId } = useLoaderData({
+    from: '/_auth/$project/board',
+  });
+
+  const toast = useToast();
+
+  const { createTask } = useBoardStore();
+
+  const {
+    createTask: { mutate: createTaskMutate },
+  } = useBoardMutations(projectId);
+
+  const handleCreateTask = () => {
+    const position = calculatePosition(section.tasks, -1);
+
+    createTaskMutate(
+      {
+        event: 'CREATE_TASK',
+        sectionId: section.id,
+        position,
+      },
+      {
+        onSuccess: (response) => {
+          createTask(section.id, {
+            id: response.id,
+            title: '',
+            sectionId: section.id,
+            position,
+            assignees: [],
+            labels: [],
+            subtasks: { total: 0, completed: 0 },
+          });
+        },
+        onError: () => {
+          toast.error('Failed to create task');
+        },
+      }
+    );
+  };
+
+  return (
+    <Section
+      className={cn(
+        'flex h-full w-[352px] flex-shrink-0 flex-col items-center',
+        'bg-transparent',
+        isBelow && 'border-2 border-blue-400'
+      )}
+    >
+      <SectionHeader className="flex w-full items-center justify-between gap-2 space-y-0">
+        <div className="flex items-center gap-2">
+          <SectionTitle className="text-xl">{section.name}</SectionTitle>
+          <SectionCount>{section.tasks.length}</SectionCount>
+        </div>
+        <SectionDropdownMenu>
+          <Button
+            type="button"
+            variant="ghost"
+            className="hover:text-primary w-full border-none px-0 text-black hover:bg-white"
+            onClick={handleCreateTask}
+          >
+            <PlusIcon />
+            Add Task
+          </Button>
+        </SectionDropdownMenu>
+      </SectionHeader>
+
+      <SectionContent
+        key={section.id}
+        className="flex w-full flex-1 flex-col items-center gap-2 overflow-y-auto pt-1"
+        onDragOver={onDragOver}
+        onDrop={onDrop}
+      >
+        {children}
+      </SectionContent>
+      <SectionFooter className="w-full">
+        <Button
+          variant="ghost"
+          className="w-full border-none px-0 text-black"
+          onClick={handleCreateTask}
+        >
+          <PlusIcon />
+          Add Task
+        </Button>
+      </SectionFooter>
+    </Section>
+  );
+}
+
+function SectionCount({ children }: { children: ReactNode }) {
+  return (
+    <span className="mt-0 flex h-6 w-6 items-center justify-center rounded-lg border border-gray-400 text-gray-600">
+      {children}
+    </span>
+  );
+}
+
+function SectionDropdownMenu({ children }: { children: ReactNode }) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger>
+        <Button variant="ghost" className="hover:text-primary h-6 w-6 hover:bg-transparent">
+          <HamburgerMenuIcon className="h-6 w-6" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="gap-1 bg-white p-0">
+        {children}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/client/src/features/project/board/components/KanbanTask.tsx
+++ b/apps/client/src/features/project/board/components/KanbanTask.tsx
@@ -1,0 +1,100 @@
+import { DragEvent } from 'react';
+import { motion } from 'framer-motion';
+import { Link, useLoaderData } from '@tanstack/react-router';
+import { PanelLeftOpen } from 'lucide-react';
+import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card.tsx';
+import { Task } from '@/features/project/board/types.ts';
+import { cn } from '@/lib/utils.ts';
+import { TaskTextarea } from '@/features/project/board/components/TaskTextarea.tsx';
+import { Button } from '@/components/ui/button.tsx';
+import { Badge } from '@/components/ui/badge.tsx';
+import { AssigneeAvatars } from '@/features/project/board/components/AssigneeAvatars.tsx';
+import { SubtaskProgress } from '@/features/project/board/components/SubtaskProgress.tsx';
+
+interface TaskCardProps {
+  task: Task;
+  isBelow: boolean;
+  onDragStart: (e: DragEvent) => void;
+  onDragOver: (e: DragEvent) => void;
+  onDragLeave: () => void;
+  onDrop: (e: DragEvent) => void;
+  onTitleChange: (id: number, title: string) => void;
+}
+
+export function TaskCard({
+  task,
+  isBelow,
+  onDragStart,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  onTitleChange,
+}: TaskCardProps) {
+  const { projectId } = useLoaderData({
+    from: '/_auth/$project/board',
+  });
+
+  return (
+    <motion.div
+      key={task.id}
+      layout
+      layoutId={task.id.toString()}
+      draggable
+      initial={{ opacity: 1, zIndex: 1 }}
+      animate={{
+        zIndex: isBelow ? 50 : 1,
+        scale: isBelow ? 1.02 : 1,
+      }}
+      transition={{
+        layout: { duration: 0.2 },
+        scale: { duration: 0.2 },
+      }}
+      style={{ position: 'relative' }}
+      onDragStart={(e) => onDragStart(e as unknown as DragEvent)}
+      onDrop={(e) => onDrop(e)}
+      onDragOver={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        onDragOver(e);
+      }}
+      onDragLeave={onDragLeave}
+    >
+      <Card
+        className={cn(
+          'w-56 border bg-white transition-all duration-300 md:w-80',
+          isBelow && 'border-2 border-blue-400',
+          'hover:shadow-md'
+        )}
+      >
+        <CardHeader className="flex flex-row items-start gap-2 space-y-0">
+          <TaskTextarea taskId={task.id} initialTitle={task.title} onTitleChange={onTitleChange} />
+          <Button
+            variant="ghost"
+            type="button"
+            asChild
+            className="hover:text-primary px-2 hover:bg-transparent"
+          >
+            <Link to={`/${projectId}/board/${task.id}`} className="p-0">
+              <PanelLeftOpen className="h-6 w-6" />
+            </Link>
+          </Button>
+        </CardHeader>
+        <CardContent className="flex items-end justify-between">
+          <div className="flex flex-wrap gap-1">
+            {task.labels.map((label) => (
+              <Badge key={label.id} style={{ backgroundColor: label.color }}>
+                {label.name}
+              </Badge>
+            ))}
+          </div>
+          <AssigneeAvatars assignees={task.assignees} />
+        </CardContent>
+        {task.subtasks.total > 0 && (
+          <CardFooter className="flex items-center justify-between space-y-0">
+            <SubtaskProgress total={task.subtasks.total} completed={task.subtasks.completed} />
+          </CardFooter>
+        )}
+      </Card>
+    </motion.div>
+  );
+}

--- a/apps/client/src/features/project/board/useDragAndDrop.ts
+++ b/apps/client/src/features/project/board/useDragAndDrop.ts
@@ -26,19 +26,12 @@ export const useDragAndDrop = (onDrop?: DropHandler) => {
     e.preventDefault();
 
     const draggedTaskId = Number(e.dataTransfer.getData('taskId'));
-    if (!draggedTaskId || Number.isNaN(draggedTaskId)) {
+    if (!draggedTaskId || Number.isNaN(draggedTaskId) || draggedTaskId === belowTaskId) {
       handleDragEnd();
       return;
     }
 
-    if (draggedTaskId === belowTaskId) {
-      handleDragEnd();
-      return;
-    }
-
-    if (onDrop) {
-      onDrop(sectionId, draggedTaskId);
-    }
+    onDrop?.(sectionId, draggedTaskId);
 
     handleDragEnd();
   };

--- a/apps/client/src/features/project/board/useDragAndDrop.ts
+++ b/apps/client/src/features/project/board/useDragAndDrop.ts
@@ -1,6 +1,8 @@
 import { useState, DragEvent } from 'react';
 
-export const useDragAndDrop = () => {
+type DropHandler = (sectionId: number, taskId: number) => void;
+
+export const useDragAndDrop = (onDrop?: DropHandler) => {
   const [belowSectionId, setBelowSectionId] = useState<number>(-1);
   const [belowTaskId, setBelowTaskId] = useState<number>(-1);
 
@@ -20,6 +22,27 @@ export const useDragAndDrop = () => {
     setBelowSectionId(-1);
   };
 
+  const handleDrop = (e: DragEvent, sectionId: number) => {
+    e.preventDefault();
+
+    const draggedTaskId = Number(e.dataTransfer.getData('taskId'));
+    if (!draggedTaskId || Number.isNaN(draggedTaskId)) {
+      handleDragEnd();
+      return;
+    }
+
+    if (draggedTaskId === belowTaskId) {
+      handleDragEnd();
+      return;
+    }
+
+    if (onDrop) {
+      onDrop(sectionId, draggedTaskId);
+    }
+
+    handleDragEnd();
+  };
+
   const handleDragEnd = () => {
     setBelowTaskId(-1);
     setBelowSectionId(-1);
@@ -31,6 +54,7 @@ export const useDragAndDrop = () => {
     handleDragStart,
     handleDragOver,
     handleDragLeave,
+    handleDrop,
     handleDragEnd,
   };
 };

--- a/apps/client/src/features/project/board/useDragAndDrop.ts
+++ b/apps/client/src/features/project/board/useDragAndDrop.ts
@@ -24,6 +24,7 @@ export const useDragAndDrop = (onDrop?: DropHandler) => {
 
   const handleDrop = (e: DragEvent, sectionId: number) => {
     e.preventDefault();
+    e.stopPropagation();
 
     const draggedTaskId = Number(e.dataTransfer.getData('taskId'));
     if (!draggedTaskId || Number.isNaN(draggedTaskId) || draggedTaskId === belowTaskId) {

--- a/apps/client/src/features/project/board/useDragAndDrop.ts
+++ b/apps/client/src/features/project/board/useDragAndDrop.ts
@@ -1,0 +1,36 @@
+import { useState, DragEvent } from 'react';
+
+export const useDragAndDrop = () => {
+  const [belowSectionId, setBelowSectionId] = useState<number>(-1);
+  const [belowTaskId, setBelowTaskId] = useState<number>(-1);
+
+  const handleDragStart = (e: DragEvent, sectionId: number, taskId: number) => {
+    e.dataTransfer.setData('taskId', taskId.toString());
+    e.dataTransfer.setData('sectionId', sectionId.toString());
+  };
+
+  const handleDragOver = (e: DragEvent, sectionId: number, taskId?: number) => {
+    e.preventDefault();
+    setBelowSectionId(sectionId);
+    setBelowTaskId(taskId ?? -1);
+  };
+
+  const handleDragLeave = () => {
+    setBelowTaskId(-1);
+    setBelowSectionId(-1);
+  };
+
+  const handleDragEnd = () => {
+    setBelowTaskId(-1);
+    setBelowSectionId(-1);
+  };
+
+  return {
+    belowSectionId,
+    belowTaskId,
+    handleDragStart,
+    handleDragOver,
+    handleDragLeave,
+    handleDragEnd,
+  };
+};


### PR DESCRIPTION

## 관련 이슈 번호

close #227 

## 작업 내용

- 드래그 앤 드롭 로직을 분리했습니다.
  - 이 과정에서 DropHandler 는 여전히 외부에 있는 것이 더 좋아보여서, 인자로 받도록 했습니다.
- 칸반보드를 보드 / 섹션 / 태스크로 분리했습니다.


## 고민과 학습내용

태스크와 섹션 모두 더 분리를 할 수는 있을 것 같은데 오히려 흐름이 깨지는 것 같아서, 유지했습니다.
그리고, 섹션 안에 태스크가 들어가있으면 오히려 이해하기 어려울 것 같아
아래와 같이 구성했습니다.

```tsx
<AnimatePresence mode="popLayout">
  {sections.map((section) => (
    <BoardSection
      key={section.id}
      section={section}
      isBelow={section.id === belowSectionId}
      onDrop={(e) => handleDrop(e, section.id)}
      onDragOver={(e) => handleDragOver(e, section.id)}
    >
      {section.tasks.map((task) => (
        <TaskCard
          key={task.id}
          task={task}
          isBelow={task.id === belowTaskId}
          onDragStart={(e) => handleDragStart(e, section.id, task.id)}
          onDragOver={(e) => handleDragOver(e, section.id, task.id)}
          onDragLeave={handleDragLeave}
          onDrop={(e) => handleDrop(e, section.id)}
          onTitleChange={handleTitleChange}
        />
      ))}
    </BoardSection>
  ))} 
</AnimatePresence>
```